### PR TITLE
Remove dependency to derive crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,6 @@ dependencies = [
  "inventory",
  "itertools",
  "pyo3",
- "pyo3-stub-gen-derive",
  "serde",
  "toml",
 ]
@@ -304,6 +303,7 @@ version = "0.1.0"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
+ "pyo3-stub-gen-derive",
 ]
 
 [[package]]
@@ -312,6 +312,7 @@ version = "0.1.0"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
+ "pyo3-stub-gen-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,15 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+
+description = "Stub file (*.pyi) generator for PyO3"
+repository  = "https://github.com/Jij-Inc/pyo3-stub-gen"
+keywords    = ["pyo3"]
+license     = "MIT OR Apache-2.0"
+
 [workspace.dependencies]
 pyo3-stub-gen = { version = "0.1.0", path = "pyo3-stub-gen" }
 pyo3-stub-gen-derive = { version = "0.1.0", path = "pyo3-stub-gen-derive" }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ To generate a stub file for this project, please modify it as follows:
 
 ```rust
 use pyo3::prelude::*;
-use pyo3_stub_gen::{derive::gen_stub_pyfunction, StubInfo};
+use pyo3_stub_gen::StubInfo;
+use pyo3_stub_gen_derive::gen_stub_pyfunction;
 use std::{env, path::*};
 
 #[gen_stub_pyfunction]  // Proc-macro attribute to register a function to stub file generator.

--- a/pyo3-stub-gen-derive/Cargo.toml
+++ b/pyo3-stub-gen-derive/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "pyo3-stub-gen-derive"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+
+description.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/pyo3-stub-gen-testing-mixed/Cargo.toml
+++ b/pyo3-stub-gen-testing-mixed/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3-stub-gen.workspace = true
+pyo3-stub-gen-derive.workspace = true
 pyo3.workspace = true
 
 [[bin]]

--- a/pyo3-stub-gen-testing-mixed/src/lib.rs
+++ b/pyo3-stub-gen-testing-mixed/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
-use pyo3_stub_gen::{derive::gen_stub_pyfunction, StubInfo};
+use pyo3_stub_gen::StubInfo;
+use pyo3_stub_gen_derive::gen_stub_pyfunction;
 use std::{env, path::*};
 
 /// Gather information to generate stub files

--- a/pyo3-stub-gen-testing-pure/Cargo.toml
+++ b/pyo3-stub-gen-testing-pure/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3-stub-gen.workspace = true
+pyo3-stub-gen-derive.workspace = true
 pyo3.workspace = true
 
 [[bin]]

--- a/pyo3-stub-gen-testing-pure/src/lib.rs
+++ b/pyo3-stub-gen-testing-pure/src/lib.rs
@@ -2,7 +2,8 @@
 mod readme {}
 
 use pyo3::prelude::*;
-use pyo3_stub_gen::{derive::gen_stub_pyfunction, StubInfo};
+use pyo3_stub_gen::StubInfo;
+use pyo3_stub_gen_derive::gen_stub_pyfunction;
 use std::{env, path::*};
 
 /// Gather information to generate stub files

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "pyo3-stub-gen"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-pyo3-stub-gen-derive.workspace = true
+pyo3-stub-gen-derive = { workspace = true, optional = true }
 
 anyhow.workspace = true
 inventory.workspace = true
@@ -12,3 +12,7 @@ itertools.workspace = true
 pyo3.workspace = true
 serde.workspace = true
 toml.workspace = true
+
+[features]
+default = ["derive"]
+derive = ["pyo3-stub-gen-derive"]

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -4,15 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-pyo3-stub-gen-derive = { workspace = true, optional = true }
-
 anyhow.workspace = true
 inventory.workspace = true
 itertools.workspace = true
 pyo3.workspace = true
 serde.workspace = true
 toml.workspace = true
-
-[features]
-default = ["derive"]
-derive = ["pyo3-stub-gen-derive"]

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "derive")]
-pub use pyo3_stub_gen_derive as derive;
-
 pub use inventory; // re-export to use in generated code
 
 mod generate;

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -1,5 +1,7 @@
-pub use inventory; // re-export to use in generated code
+#[cfg(feature = "derive")]
 pub use pyo3_stub_gen_derive as derive;
+
+pub use inventory; // re-export to use in generated code
 
 mod generate;
 mod pyproject;


### PR DESCRIPTION
In order to publish the `pyo3-stub-gen` crate to crates.io, `pyo3-stub-gen-derive` must be exists in crates.io even if it is optional dependency.