### PR TITLE
Re-enable `pyo3_stub_gen::derive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "inventory",
  "itertools",
  "pyo3",
+ "pyo3-stub-gen-derive",
  "serde",
  "toml",
 ]
@@ -303,7 +304,6 @@ version = "0.1.0"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
- "pyo3-stub-gen-derive",
 ]
 
 [[package]]
@@ -312,7 +312,6 @@ version = "0.1.0"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
- "pyo3-stub-gen-derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "inventory",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "insta",
  "inventory",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen-testing-mixed"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen-testing-pure"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 description = "Stub file (*.pyi) generator for PyO3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,6 @@ license     = "MIT OR Apache-2.0"
 readme      = "README.md"
 
 [workspace.dependencies]
-pyo3-stub-gen = { version = "0.1.0", path = "pyo3-stub-gen" }
-pyo3-stub-gen-derive = { version = "0.1.0", path = "pyo3-stub-gen-derive" }
-
 anyhow = "1.0.86"
 insta = "1.39.0"
 inventory = "0.3.15"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ To generate a stub file for this project, please modify it as follows:
 
 ```rust
 use pyo3::prelude::*;
-use pyo3_stub_gen::StubInfo;
-use pyo3_stub_gen_derive::gen_stub_pyfunction;
+use pyo3_stub_gen::{derive::gen_stub_pyfunction, StubInfo};
 use std::{env, path::*};
 
 #[gen_stub_pyfunction]  // Proc-macro attribute to register a function to stub file generator.

--- a/pyo3-stub-gen-derive/Cargo.toml
+++ b/pyo3-stub-gen-derive/Cargo.toml
@@ -18,8 +18,7 @@ quote.workspace = true
 syn = { workspace = true, features = ["full", "extra-traits"] }
 
 [dev-dependencies]
-pyo3-stub-gen.workspace = true
-
+pyo3-stub-gen = { version = "0.1.0", path = "../pyo3-stub-gen" }
 insta.workspace = true
 inventory.workspace = true
 prettyplease.workspace = true

--- a/pyo3-stub-gen-derive/Cargo.toml
+++ b/pyo3-stub-gen-derive/Cargo.toml
@@ -18,7 +18,7 @@ quote.workspace = true
 syn = { workspace = true, features = ["full", "extra-traits"] }
 
 [dev-dependencies]
-pyo3-stub-gen = { version = "0.1.0", path = "../pyo3-stub-gen" }
+pyo3-stub-gen = { path = "../pyo3-stub-gen" }
 insta.workspace = true
 inventory.workspace = true
 prettyplease.workspace = true

--- a/pyo3-stub-gen-testing-mixed/Cargo.toml
+++ b/pyo3-stub-gen-testing-mixed/Cargo.toml
@@ -8,7 +8,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3-stub-gen.workspace = true
-pyo3-stub-gen-derive.workspace = true
 pyo3.workspace = true
 
 [[bin]]

--- a/pyo3-stub-gen-testing-mixed/Cargo.toml
+++ b/pyo3-stub-gen-testing-mixed/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3-stub-gen.workspace = true
+pyo3-stub-gen = { path = "../pyo3-stub-gen" }
 pyo3.workspace = true
 
 [[bin]]

--- a/pyo3-stub-gen-testing-mixed/Cargo.toml
+++ b/pyo3-stub-gen-testing-mixed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-stub-gen-testing-mixed"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/pyo3-stub-gen-testing-mixed/src/lib.rs
+++ b/pyo3-stub-gen-testing-mixed/src/lib.rs
@@ -1,6 +1,5 @@
 use pyo3::prelude::*;
-use pyo3_stub_gen::StubInfo;
-use pyo3_stub_gen_derive::gen_stub_pyfunction;
+use pyo3_stub_gen::{derive::gen_stub_pyfunction, StubInfo};
 use std::{env, path::*};
 
 /// Gather information to generate stub files

--- a/pyo3-stub-gen-testing-pure/Cargo.toml
+++ b/pyo3-stub-gen-testing-pure/Cargo.toml
@@ -8,7 +8,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3-stub-gen.workspace = true
-pyo3-stub-gen-derive.workspace = true
 pyo3.workspace = true
 
 [[bin]]

--- a/pyo3-stub-gen-testing-pure/Cargo.toml
+++ b/pyo3-stub-gen-testing-pure/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3-stub-gen.workspace = true
+pyo3-stub-gen = { path = "../pyo3-stub-gen" }
 pyo3.workspace = true
 
 [[bin]]

--- a/pyo3-stub-gen-testing-pure/Cargo.toml
+++ b/pyo3-stub-gen-testing-pure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-stub-gen-testing-pure"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/pyo3-stub-gen-testing-pure/src/lib.rs
+++ b/pyo3-stub-gen-testing-pure/src/lib.rs
@@ -2,8 +2,7 @@
 mod readme {}
 
 use pyo3::prelude::*;
-use pyo3_stub_gen::StubInfo;
-use pyo3_stub_gen_derive::gen_stub_pyfunction;
+use pyo3_stub_gen::{derive::gen_stub_pyfunction, StubInfo};
 use std::{env, path::*};
 
 /// Gather information to generate stub files

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -15,3 +15,9 @@ itertools.workspace = true
 pyo3.workspace = true
 serde.workspace = true
 toml.workspace = true
+
+pyo3-stub-gen-derive = { workspace = true, optional = true }
+
+[features]
+default = ["derive"]
+derive = ["pyo3-stub-gen-derive"]

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -16,7 +16,10 @@ pyo3.workspace = true
 serde.workspace = true
 toml.workspace = true
 
-pyo3-stub-gen-derive = { workspace = true, optional = true }
+[dependencies.pyo3-stub-gen-derive]
+version = "0.1.0"
+path = "../pyo3-stub-gen-derive"
+optional = true
 
 [features]
 default = ["derive"]

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -19,8 +19,3 @@ toml.workspace = true
 [dependencies.pyo3-stub-gen-derive]
 version = "0.1.0"
 path = "../pyo3-stub-gen-derive"
-optional = true
-
-[features]
-default = ["derive"]
-derive = ["pyo3-stub-gen-derive"]

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -17,5 +17,5 @@ serde.workspace = true
 toml.workspace = true
 
 [dependencies.pyo3-stub-gen-derive]
-version = "0.1.0"
+version = "0.1.1"
 path = "../pyo3-stub-gen-derive"

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -1,8 +1,5 @@
-///
-#[cfg(feature = "derive")]
-pub use pyo3_stub_gen_derive as derive;
-
-pub use inventory; // re-export to use in generated code
+pub use inventory;
+pub use pyo3_stub_gen_derive as derive; // re-export to use in generated code
 
 mod generate;
 mod pyproject;

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "derive")]
+pub use pyo3_stub_gen_derive as derive;
+
 pub use inventory; // re-export to use in generated code
 
 mod generate;

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -1,3 +1,4 @@
+///
 #[cfg(feature = "derive")]
 pub use pyo3_stub_gen_derive as derive;
 


### PR DESCRIPTION
Reverts #15 with modified Cargo.toml setting.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#the-role-of-the-version-key
> Note: [crates.io](https://crates.io/) does not allow packages to be published with dependencies on code published outside of [crates.io](https://crates.io/) itself ([dev-dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies) are ignored).

So the problem is `dev-dependency.pyo3-stub-gen` in `pyo3-stub-gen-derive/Cargo.toml` specifies version `0.1.0`, which did not exists on crates.io. This version specification is not needed, and removed in this PR.

Then, we do not have cyclic dependency. We can release `pyo3-stub-gen-derive` first, and then `pyo3-stub-gen`.