### PR TITLE
pyo3 v0.21+ compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,12 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "bitflags"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,9 +58,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
@@ -130,16 +124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,29 +143,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -210,15 +171,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "831e8e819a138c36e212f3af3fd9eeffed6bf1510a805af35b0edee5ffa59433"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -228,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "1e8730e591b14492a8945cdff32f089250b05f5accecf74aeddf9e8272ce1fa8"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -238,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "5e97e919d2df92eb88ca80a037969f44e5e70356559654962cbb3316d00300c6"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -248,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "eb57983022ad41f9e683a599f2fd13c3664d7063a3ac5714cae4b7bee7d3f206"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -260,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "ec480c0c51ddec81019531705acac51bcdbeae563557c982aa8263bb96880372"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -324,21 +285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,12 +318,6 @@ name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
-
-[[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 anyhow = "1.0.86"
 insta = "1.39.0"
 inventory = "0.3.15"
-itertools = "0.12.1"
+itertools = "0.13.0"
 prettyplease = "0.2.20"
 proc-macro2 = "1.0.86"
 pyo3 = { version = ">=0.21", features = ["experimental-inspect"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [workspace.dependencies]
-anyhow = "1.0.86"
-insta = "1.39.0"
-inventory = "0.3.15"
-itertools = "0.13.0"
-prettyplease = "0.2.20"
-proc-macro2 = "1.0.86"
+anyhow = "1.0"
+insta = "1.39"
+inventory = "0.3"
+itertools = "0.13"
+prettyplease = "0.2"
+proc-macro2 = "1.0"
 pyo3 = { version = ">=0.21", features = ["experimental-inspect"] }
-quote = "1.0.36"
-serde = { version = "1.0.204", features = ["derive"] }
-syn = "2.0.72"
-toml = "0.8.19"
+quote = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+syn = "2.0"
+toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ version = "0.1.2"
 edition = "2021"
 
 description = "Stub file (*.pyi) generator for PyO3"
-repository  = "https://github.com/Jij-Inc/pyo3-stub-gen"
-keywords    = ["pyo3"]
-license     = "MIT OR Apache-2.0"
-readme      = "README.md"
+repository = "https://github.com/Jij-Inc/pyo3-stub-gen"
+keywords = ["pyo3"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
 
 [workspace.dependencies]
 anyhow = "1.0.86"
@@ -24,7 +24,7 @@ inventory = "0.3.15"
 itertools = "0.12.1"
 prettyplease = "0.2.20"
 proc-macro2 = "1.0.86"
-pyo3 = { version = "0.20.3", features = ["experimental-inspect"] }
+pyo3 = { version = ">=0.21", features = ["experimental-inspect"] }
 quote = "1.0.36"
 serde = { version = "1.0.204", features = ["derive"] }
 syn = "2.0.72"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
 }
 
 #[pymodule]
-fn pyo3_stub_gen_testing(_py: Python, m: &PyModule) -> PyResult<()> {
+fn pyo3_stub_gen_testing(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
 }
@@ -38,7 +38,7 @@ fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
 }
 
 #[pymodule]
-fn pyo3_stub_gen_testing(_py: Python, m: &PyModule) -> PyResult<()> {
+fn pyo3_stub_gen_testing(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
 }

--- a/pyo3-stub-gen-testing-mixed/src/lib.rs
+++ b/pyo3-stub-gen-testing-mixed/src/lib.rs
@@ -17,7 +17,7 @@ fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
 
 /// Initializes the Python module
 #[pymodule]
-fn my_rust_pkg(_py: Python, m: &PyModule) -> PyResult<()> {
+fn my_rust_pkg(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
 }

--- a/pyo3-stub-gen-testing-pure/src/lib.rs
+++ b/pyo3-stub-gen-testing-pure/src/lib.rs
@@ -20,7 +20,7 @@ fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
 
 /// Initializes the Python module
 #[pymodule]
-fn pyo3_stub_gen_testing_pure(_py: Python, m: &PyModule) -> PyResult<()> {
+fn pyo3_stub_gen_testing_pure(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
It makes sense to just drop 0.20 support since it uses now-deprecated syntax (`Bound` was introduced in 0.21 and is here to stay).

Also relaxed version requirements down to minor versions (so it doesn't cause conflicts like toml 0.8.17 vs 0.8.19 with other lockfiles, just had it happen). This being a library, minor versions in deps usually make more sense.

Fixes #20 