### PR TITLE
Helper macro `define_stub_info_gatherer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ To generate a stub file for this project, please modify it as follows:
 
 ```rust
 use pyo3::prelude::*;
-use pyo3_stub_gen::{derive::gen_stub_pyfunction, StubInfo};
-use std::{env, path::*};
+use pyo3_stub_gen::{derive::gen_stub_pyfunction, define_stub_info_gatherer};
 
 #[gen_stub_pyfunction]  // Proc-macro attribute to register a function to stub file generator.
 #[pyfunction]
@@ -43,12 +42,8 @@ fn pyo3_stub_gen_testing(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
-/// Create stub file generator `StubInfo` for this project
-pub fn stub_info() -> pyo3_stub_gen::Result<StubInfo> {
-    let manifest_dir: &Path = env!("CARGO_MANIFEST_DIR").as_ref();
-    // Get Python project name from pyproject.toml
-    StubInfo::from_pyproject_toml(manifest_dir.join("pyproject.toml"))
-}
+// Define a function to gather stub information.
+define_stub_info_gatherer!(stub_info);
 ```
 
 And then, create an executable target in `src/bin/stub_gen.rs`:
@@ -57,6 +52,7 @@ And then, create an executable target in `src/bin/stub_gen.rs`:
 use pyo3_stub_gen::Result;
 
 fn main() -> Result<()> {
+    // `stub_info` is a function defined by `define_stub_info_gatherer!` macro.
     let stub = pyo3_stub_gen_testing_pure::stub_info()?;
     stub.generate()?;
     Ok(())

--- a/pyo3-stub-gen-testing-mixed/src/lib.rs
+++ b/pyo3-stub-gen-testing-mixed/src/lib.rs
@@ -1,12 +1,5 @@
 use pyo3::prelude::*;
-use pyo3_stub_gen::{derive::gen_stub_pyfunction, StubInfo};
-use std::{env, path::*};
-
-/// Gather information to generate stub files
-pub fn stub_info() -> pyo3_stub_gen::Result<StubInfo> {
-    let manifest_dir: &Path = env!("CARGO_MANIFEST_DIR").as_ref();
-    StubInfo::from_pyproject_toml(manifest_dir.join("pyproject.toml"))
-}
+use pyo3_stub_gen::{define_stub_info_gatherer, derive::gen_stub_pyfunction};
 
 /// Returns the sum of two numbers as a string.
 #[gen_stub_pyfunction]
@@ -21,6 +14,8 @@ fn my_rust_pkg(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
 }
+
+define_stub_info_gatherer!(stub_info);
 
 /// Test of unit test for testing link problem
 #[cfg(test)]

--- a/pyo3-stub-gen-testing-pure/src/lib.rs
+++ b/pyo3-stub-gen-testing-pure/src/lib.rs
@@ -2,14 +2,7 @@
 mod readme {}
 
 use pyo3::prelude::*;
-use pyo3_stub_gen::{derive::gen_stub_pyfunction, StubInfo};
-use std::{env, path::*};
-
-/// Gather information to generate stub files
-pub fn stub_info() -> pyo3_stub_gen::Result<StubInfo> {
-    let manifest_dir: &Path = env!("CARGO_MANIFEST_DIR").as_ref();
-    StubInfo::from_pyproject_toml(manifest_dir.join("pyproject.toml"))
-}
+use pyo3_stub_gen::{define_stub_info_gatherer, derive::gen_stub_pyfunction};
 
 /// Returns the sum of two numbers as a string.
 #[gen_stub_pyfunction]
@@ -24,6 +17,8 @@ fn pyo3_stub_gen_testing_pure(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
 }
+
+define_stub_info_gatherer!(stub_info);
 
 /// Test of unit test for testing link problem
 #[cfg(test)]

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -134,3 +134,14 @@ pub mod type_info;
 
 pub type Result<T> = anyhow::Result<T>;
 pub use generate::StubInfo;
+
+#[macro_export]
+macro_rules! define_stub_info_gatherer {
+    ($function_name:ident) => {
+        /// Auto-generated function to gather information to generate stub files
+        pub fn $function_name() -> $crate::Result<$crate::StubInfo> {
+            let manifest_dir: &::std::path::Path = env!("CARGO_MANIFEST_DIR").as_ref();
+            $crate::StubInfo::from_pyproject_toml(manifest_dir.join("pyproject.toml"))
+        }
+    };
+}

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate creates stub files in following two steps using [inventory] crate:
+//! This crate creates stub files in following three steps using [inventory] crate:
 //!
 //! Define type information in Rust code (or by proc-macro)
 //! ---------------------------------------------------------
@@ -84,9 +84,30 @@
 //! However, we need to gather these [type_info::PyClassInfo] definitions to generate stub files,
 //! and the above [inventory::submit] is for it.
 //!
-//! Gathering type information and generating stub file
-//! ----------------------------------------------------
-//! [inventory::iter] makes it possible to gather distributed [type_info::PyClassInfo] in the crate into a single place.
+//! Gather type information into [StubInfo]
+//! ----------------------------------------
+//! [inventory] crate provides a mechanism to gather [inventory::submit]ted information when the library is loaded.
+//! To access these information through [inventory::iter], we need to define a gather function in the crate.
+//! Typically, this is done by following:
+//!
+//! ```rust
+//! use pyo3_stub_gen::{StubInfo, Result};
+//!
+//! pub fn stub_info() -> Result<StubInfo> {
+//!     let manifest_dir: &::std::path::Path = env!("CARGO_MANIFEST_DIR").as_ref();
+//!     StubInfo::from_pyproject_toml(manifest_dir.join("pyproject.toml"))
+//! }
+//! ```
+//!
+//! There is a helper macro to define it easily:
+//!
+//! ```rust
+//! pyo3_stub_gen::define_stub_info_gatherer!(sub_info);
+//! ```
+//!
+//! Generate stub file from [StubInfo]
+//! -----------------------------------
+//! [StubInfo] translates [type_info::PyClassInfo] and other information into a form helpful for generating stub files while gathering.
 //!
 //! [generate] module provides structs implementing [std::fmt::Display] to generate corresponding parts of stub file.
 //! For example, [generate::MethodDef] generates Python class method definition as follows:
@@ -135,6 +156,12 @@ pub mod type_info;
 pub type Result<T> = anyhow::Result<T>;
 pub use generate::StubInfo;
 
+/// Create a function to initialize [StubInfo] from `pyproject.toml` in `CARGO_MANIFEST_DIR`.
+///
+/// If `pyproject.toml` is in another place, you need to create a function to call [StubInfo::from_pyproject_toml] manually.
+/// This must be placed in your PyO3 library crate, i.e. same crate where [inventory::submit]ted,
+/// not in `gen_stub` executables due to [inventory] mechanism.
+///
 #[macro_export]
 macro_rules! define_stub_info_gatherer {
     ($function_name:ident) => {


### PR DESCRIPTION
- Add a macro `define_stub_info_gatherer` to reduce user side code.
- Write more about gathering phase in crate-level documents