### PR TITLE
Module variable

### DIFF
--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -6,6 +6,7 @@ import pathlib
 import typing
 from enum import Enum, auto
 
+MY_CONSTANT: int
 class A:
     x: int
     def __new__(cls,x:int): ...

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -3,7 +3,7 @@ mod readme {}
 
 use ahash::RandomState;
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::*};
-use pyo3_stub_gen::{create_exception, define_stub_info_gatherer, derive::*};
+use pyo3_stub_gen::{create_exception, define_stub_info_gatherer, derive::*, module_variable};
 use std::{collections::HashMap, path::PathBuf};
 
 /// Returns the sum of two numbers as a string.
@@ -65,6 +65,7 @@ fn create_a(x: usize) -> A {
 }
 
 create_exception!(pure, MyError, PyRuntimeError);
+module_variable!(pure, MY_CONSTANT: usize);
 
 /// Returns the length of the string.
 #[gen_stub_pyfunction]
@@ -103,6 +104,7 @@ pub enum Number {
 #[pymodule]
 fn pure(m: &Bound<PyModule>) -> PyResult<()> {
     m.add("MyError", m.py().get_type_bound::<MyError>())?;
+    m.add("MY_CONSTANT", 19937)?;
     m.add_class::<A>()?;
     m.add_class::<Number>()?;
     m.add_function(wrap_pyfunction!(sum, m)?)?;

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -65,7 +65,6 @@ fn create_a(x: usize) -> A {
 }
 
 create_exception!(pure, MyError, PyRuntimeError);
-module_variable!(pure, MY_CONSTANT: usize);
 
 /// Returns the length of the string.
 #[gen_stub_pyfunction]
@@ -99,6 +98,8 @@ pub enum Number {
     #[pyo3(name = "INTEGER")]
     Integer,
 }
+
+module_variable!("pure", "MY_CONSTANT", usize);
 
 /// Initializes the Python module
 #[pymodule]

--- a/pyo3-stub-gen/src/generate.rs
+++ b/pyo3-stub-gen/src/generate.rs
@@ -10,6 +10,7 @@ mod method;
 mod module;
 mod new;
 mod stub_info;
+mod variable;
 
 pub use arg::*;
 pub use class::*;
@@ -21,6 +22,7 @@ pub use method::*;
 pub use module::*;
 pub use new::*;
 pub use stub_info::*;
+pub use variable::*;
 
 use crate::stub_type::ModuleRef;
 use std::collections::HashSet;

--- a/pyo3-stub-gen/src/generate/module.rs
+++ b/pyo3-stub-gen/src/generate/module.rs
@@ -13,6 +13,7 @@ pub struct Module {
     pub enum_: BTreeMap<TypeId, EnumDef>,
     pub function: BTreeMap<&'static str, FunctionDef>,
     pub error: BTreeMap<&'static str, ErrorDef>,
+    pub variables: BTreeMap<&'static str, VariableDef>,
     pub name: String,
     pub default_module_name: String,
     /// Direct submodules of this module.
@@ -51,6 +52,9 @@ impl fmt::Display for Module {
         }
         writeln!(f)?;
 
+        for var in self.variables.values() {
+            writeln!(f, "{}", var)?;
+        }
         for class in self.class.values().sorted_by_key(|class| class.name) {
             write!(f, "{}", class)?;
         }

--- a/pyo3-stub-gen/src/generate/stub_info.rs
+++ b/pyo3-stub-gen/src/generate/stub_info.rs
@@ -108,6 +108,12 @@ impl StubInfoBuilder {
             .insert(info.name, ErrorDef::from(info));
     }
 
+    fn add_variable(&mut self, info: &PyVariableInfo) {
+        self.get_module(Some(info.module))
+            .variables
+            .insert(info.name, VariableDef::from(info));
+    }
+
     fn add_methods(&mut self, info: &PyMethodsInfo) {
         let struct_id = (info.struct_id)();
         for module in self.modules.values_mut() {
@@ -142,6 +148,9 @@ impl StubInfoBuilder {
         }
         for info in inventory::iter::<PyErrorInfo> {
             self.add_error(info);
+        }
+        for info in inventory::iter::<PyVariableInfo> {
+            self.add_variable(info);
         }
         for info in inventory::iter::<PyMethodsInfo> {
             self.add_methods(info);

--- a/pyo3-stub-gen/src/generate/variable.rs
+++ b/pyo3-stub-gen/src/generate/variable.rs
@@ -12,7 +12,7 @@ impl From<&PyVariableInfo> for VariableDef {
     fn from(info: &PyVariableInfo) -> Self {
         Self {
             name: info.name,
-            type_: (info.type_)(),
+            type_: (info.r#type)(),
         }
     }
 }

--- a/pyo3-stub-gen/src/generate/variable.rs
+++ b/pyo3-stub-gen/src/generate/variable.rs
@@ -1,0 +1,24 @@
+use std::fmt;
+
+use crate::{type_info::PyVariableInfo, TypeInfo};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VariableDef {
+    pub name: &'static str,
+    pub type_: TypeInfo,
+}
+
+impl From<&PyVariableInfo> for VariableDef {
+    fn from(info: &PyVariableInfo) -> Self {
+        Self {
+            name: info.name,
+            type_: (info.type_)(),
+        }
+    }
+}
+
+impl fmt::Display for VariableDef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", self.name, self.type_)
+    }
+}

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -175,3 +175,16 @@ macro_rules! define_stub_info_gatherer {
         }
     };
 }
+
+#[macro_export]
+macro_rules! module_variable {
+    ($module:ident, $name:ident: $ty:ty) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyVariableInfo{
+                name: stringify!($name),
+                module: stringify!($module),
+                r#type: <$ty as $crate::PyStubType>::type_output,
+            }
+        }
+    };
+}

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -178,11 +178,11 @@ macro_rules! define_stub_info_gatherer {
 
 #[macro_export]
 macro_rules! module_variable {
-    ($module:ident, $name:ident: $ty:ty) => {
+    ($module:expr, $name:expr, $ty:ty) => {
         $crate::inventory::submit! {
             $crate::type_info::PyVariableInfo{
-                name: stringify!($name),
-                module: stringify!($module),
+                name: $name,
+                module: $module,
                 r#type: <$ty as $crate::PyStubType>::type_output,
             }
         }

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -137,3 +137,12 @@ pub struct PyErrorInfo {
 }
 
 inventory::collect!(PyErrorInfo);
+
+#[derive(Debug)]
+pub struct PyVariableInfo {
+    pub name: &'static str,
+    pub module: &'static str,
+    pub type_: fn() -> TypeInfo,
+}
+
+inventory::collect!(PyVariableInfo);

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -142,7 +142,7 @@ inventory::collect!(PyErrorInfo);
 pub struct PyVariableInfo {
     pub name: &'static str,
     pub module: &'static str,
-    pub type_: fn() -> TypeInfo,
+    pub r#type: fn() -> TypeInfo,
 }
 
 inventory::collect!(PyVariableInfo);


### PR DESCRIPTION
Annotation in Rust side:

```rust
module_variable!("pure", "MY_CONSTANT", usize);
```

will creates module variable in `pure.pyi`

```python
MY_CONSTANT: int
```
