### PR TITLE
Add `chrono` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,10 +107,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "cc"
+version = "1.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
 
 [[package]]
 name = "colorchoice"
@@ -114,6 +158,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "either"
@@ -186,6 +236,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -504,6 +586,7 @@ name = "pyo3-stub-gen"
 version = "0.6.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "inventory",
  "itertools",
  "log",
@@ -625,6 +708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +805,70 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -19,11 +19,13 @@ numpy = { workspace = true, optional = true }
 pyo3.workspace = true
 serde.workspace = true
 toml.workspace = true
+chrono = {version = "0.4.38", optional = true}
 
 [dependencies.pyo3-stub-gen-derive]
 version = "0.6.1"
 path = "../pyo3-stub-gen-derive"
 
 [features]
-default = ["numpy"]
+default = ["numpy", "chrono"]
 numpy = ["dep:numpy"]
+chrono = ["dep:chrono"]

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -19,13 +19,12 @@ numpy = { workspace = true, optional = true }
 pyo3.workspace = true
 serde.workspace = true
 toml.workspace = true
-chrono = {version = "0.4.38", optional = true}
+chrono = "0.4.38"
 
 [dependencies.pyo3-stub-gen-derive]
 version = "0.6.1"
 path = "../pyo3-stub-gen-derive"
 
 [features]
-default = ["numpy", "chrono"]
+default = ["numpy"]
 numpy = ["dep:numpy"]
-chrono = ["dep:chrono"]

--- a/pyo3-stub-gen/src/stub_type/builtins.rs
+++ b/pyo3-stub-gen/src/stub_type/builtins.rs
@@ -5,7 +5,10 @@ use std::{
     borrow::Cow,
     ffi::{OsStr, OsString},
     path::PathBuf,
+    time::SystemTime,
 };
+
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 
 macro_rules! impl_builtin {
     ($ty:ty, $pytype:expr) => {
@@ -68,32 +71,17 @@ impl PyStubType for PathBuf {
     }
 }
 
-/// Adding chrono types supported by pyo3 [here](https://pyo3.rs/v0.22.2/conversions/tables)
-#[cfg(feature = "chrono")]
-mod chrono_exports {
-    use std::time::SystemTime;
-
-    use super::{PyStubType, TypeInfo};
-    use chrono::{
-        DateTime, Duration, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc,
-    };
-
-    impl<Tz: TimeZone> PyStubType for DateTime<Tz> {
-        fn type_output() -> TypeInfo {
-            TypeInfo::with_module("datetime.datetime", "datetime".into())
-        }
+impl<Tz: TimeZone> PyStubType for DateTime<Tz> {
+    fn type_output() -> TypeInfo {
+        TypeInfo::with_module("datetime.datetime", "datetime".into())
     }
-
-    impl_with_module!(SystemTime, "datetime.datetime", "datetime");
-    impl_with_module!(NaiveDateTime, "datetime.datetime", "datetime");
-    impl_with_module!(NaiveDate, "datetime.date", "datetime");
-    impl_with_module!(NaiveTime, "datetime.time", "datetime");
-    impl_with_module!(FixedOffset, "datetime.tzinfo", "datetime");
-    impl_with_module!(Utc, "datetime.tzinfo", "datetime");
-    impl_with_module!(std::time::Duration, "datetime.timedelta", "datetime");
-    impl_with_module!(Duration, "datetime.timedelta", "datetime");
 }
 
-#[allow(unused_imports)]
-#[cfg(feature = "chrono")]
-pub use chrono_exports::*;
+impl_with_module!(SystemTime, "datetime.datetime", "datetime");
+impl_with_module!(NaiveDateTime, "datetime.datetime", "datetime");
+impl_with_module!(NaiveDate, "datetime.date", "datetime");
+impl_with_module!(NaiveTime, "datetime.time", "datetime");
+impl_with_module!(FixedOffset, "datetime.tzinfo", "datetime");
+impl_with_module!(Utc, "datetime.tzinfo", "datetime");
+impl_with_module!(std::time::Duration, "datetime.timedelta", "datetime");
+impl_with_module!(chrono::Duration, "datetime.timedelta", "datetime");


### PR DESCRIPTION
Fix for #77. Implemented as a new feature `chrono` just like pyo3 does.
I didn't know whether to make it a default feature, but it is now following the pattern from `numpy`.