### PR TITLE
Add &[u8] as bytes

### DIFF
--- a/pyo3-stub-gen/src/stub_type/builtins.rs
+++ b/pyo3-stub-gen/src/stub_type/builtins.rs
@@ -47,6 +47,8 @@ impl_builtin!(OsString, "str");
 impl_builtin!(Cow<'_, str>, "str");
 impl_builtin!(Cow<'_, OsStr>, "str");
 
+impl_builtin!(&[u8], "bytes");
+
 impl PyStubType for PathBuf {
     fn type_output() -> TypeInfo {
         TypeInfo::builtin("str")


### PR DESCRIPTION
As defined in https://pyo3.rs/v0.22.2/conversions/tables#argument-types, &[u8] are mapped to "bytes"

I tried also to add `Vec<u8>` and `Cow<u8>`, however it conflicted with the definitions in `collections.rs` and I’m not sure what would be the right approach to it.