### PR TITLE
Parse signature with default value as python default value

### DIFF
--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -21,7 +21,13 @@ class Number(Enum):
     FLOAT = auto()
     INTEGER = auto()
 
+def add_two_number(x:int = 0, y:int = 0) -> int:
+    ...
+
 def ahash_dict() -> dict[str, int]:
+    ...
+
+def calculate_average(numbers:typing.Sequence[float], precision:typing.Optional[int] = None) -> float:
     ...
 
 def create_a(x:int) -> A:

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -14,6 +14,23 @@ fn sum(v: Vec<u32>) -> u32 {
 }
 
 #[gen_stub_pyfunction]
+#[pyfunction(signature=(x=0, y=0))]
+fn add_two_number(x: i32, y: i32) -> i32 {
+    x + y
+}
+
+#[gen_stub_pyfunction]
+#[pyfunction(signature=(numbers, precision=None))]
+fn calculate_average(numbers: Vec<f64>, precision: Option<usize>) -> f64 {
+    let total: f64 = numbers.iter().sum();
+    let average = total / numbers.len() as f64;
+    match precision {
+        Some(p) => (average * 10f64.powi(p as i32)).round() / 10f64.powi(p as i32),
+        None => average,
+    }
+}
+
+#[gen_stub_pyfunction]
 #[pyfunction]
 fn read_dict(dict: HashMap<usize, HashMap<usize, usize>>) {
     for (k, v) in dict {
@@ -109,6 +126,8 @@ fn pure(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<A>()?;
     m.add_class::<Number>()?;
     m.add_function(wrap_pyfunction!(sum, m)?)?;
+    m.add_function(wrap_pyfunction!(add_two_number, m)?)?;
+    m.add_function(wrap_pyfunction!(calculate_average, m)?)?;
     m.add_function(wrap_pyfunction!(create_dict, m)?)?;
     m.add_function(wrap_pyfunction!(read_dict, m)?)?;
     m.add_function(wrap_pyfunction!(create_a, m)?)?;

--- a/examples/pure/tests/test_python.py
+++ b/examples/pure/tests/test_python.py
@@ -1,4 +1,4 @@
-from pure import sum, create_dict, read_dict, echo_path, ahash_dict
+from pure import sum, create_dict, read_dict, echo_path, ahash_dict, add_two_number, calculate_average
 import pytest
 import pathlib
 
@@ -7,6 +7,14 @@ def test_sum():
     assert sum([1, 2]) == 3
     assert sum((1, 2)) == 3
 
+def test_add_two_number():
+    assert add_two_number() == 0
+    assert add_two_number(10) == 10
+    assert add_two_number(24, 36) == 60
+
+def test_calculate_average():
+    assert calculate_average([1,2,3,4]) == 2.5
+    assert calculate_average([1,2,3,4], 2) == 2.50
 
 def test_create_dict():
     assert create_dict(3) == {0: [], 1: [0], 2: [0, 1]}

--- a/pyo3-stub-gen-derive/src/gen_stub/signature.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/signature.rs
@@ -45,7 +45,9 @@ impl ToTokens for SignatureArg {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
         match self {
             SignatureArg::Ident(ident) => tokens.append_all(quote! { #ident }),
-            SignatureArg::Assign(ident, _eq, _value) => tokens.append_all(quote! { #ident = ... }),
+            SignatureArg::Assign(ident, _eq, value) => {
+                tokens.append_all(quote! { #ident = #value })
+            }
             SignatureArg::Star(star) => tokens.append_all(quote! { #star }),
             SignatureArg::Args(star, ident) => tokens.append_all(quote! { #star #ident }),
             SignatureArg::Keywords(star1, star2, ident) => {
@@ -77,7 +79,7 @@ impl ToTokens for Signature {
             .iter()
             .map(|arg| arg.to_token_stream().to_string())
             .collect::<Vec<String>>()
-            .join(",");
+            .join(", ");
         tokens.append_all(quote! { #sig });
     }
 }


### PR DESCRIPTION
Hi, I have a problem in the generated .pyi results, where it wouldn't show the default value and making the Option<...>
Thus I have added the ability for creating below snippet from the

lib.rs
```
#[gen_stub_pyfunction]
#[pyfunction(signature=(x=0, y=0))]
fn add_two_number(x: i32, y: i32) -> i32 {...}

#[gen_stub_pyfunction]
#[pyfunction(signature=(numbers, precision=None))]
fn calculate_average(numbers: Vec<f64>, precision: Option<usize>) -> f64 {...}
```

pyi
```
def add_two_number(x:int = 0, y:int = 0) -> int:
    ...

def calculate_average(numbers:typing.Sequence[float], precision:typing.Optional[int] = None) -> float:
    ...
```
which previously was (in the python side we couldn't see the default value)
```
def add_two_number(x:int = ..., y:int = ...) -> int:
    ...

def calculate_average(numbers:typing.Sequence[float], precision:typing.Optional[int] = ...) -> float:
    ...
```

helper
```
(function) def add_two_number(
    x: int = 0,
    y: int = 0
) -> int

(function) def calculate_average(
    numbers: Sequence[float],
    precision: int | None = None
) -> float
```


I think some of this is caused by the changes made in the pyo3 which changes the Option<..> not to have default value of None
I would hope this could help the autocomplete in the python side.

If there is anything not fit your code structure or any changes need to be made, please let me know.
Thank you in advance