### PR TITLE
Fix PyUntypedArray

### DIFF
--- a/pyo3-stub-gen/src/stub_type/numpy.rs
+++ b/pyo3-stub-gen/src/stub_type/numpy.rs
@@ -46,7 +46,7 @@ impl<T: NumPyScalar, D> PyStubType for PyArray<T, D> {
 impl PyStubType for PyUntypedArray {
     fn type_output() -> TypeInfo {
         TypeInfo {
-            name: "numpy.NDArray[typing.Any]".into(),
+            name: "numpy.typing.NDArray[typing.Any]".into(),
             import: hashset!["numpy.typing".into(), "typing".into()],
         }
     }


### PR DESCRIPTION
Sorry, I spelled it `numpy.NDArray` instead of `numpy.typing.NDArray`.

That’s because I went back and forth between `numpy.ndarray` and `numpy.typing.NDArray[typing.Any]` (which are the same thing, so it wouldn’t matter, but I thought the latter was more explicit).