### PR TITLE
use `#[gen_stub(signature = (xxx))]` to specify the signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ fn your_module_name(m: &Bound<PyModule>) -> PyResult<()> {
 define_stub_info_gatherer!(stub_info);
 ```
 
+**Optional**, you can use `#[gen_stub(signature = (xxx))]` to override/specify the signature in stub file, avaiable in both `pyfunction` and `pymethods`.
+``` rust
+#[gen_stub_pyfunction]  // Proc-macro attribute to register a function to stub file generator.
+#[gen_stub(signature = (a: int = 2, b: int = 3))] // Optional, override/specify the signature in stub file.
+#[pyfunction]
+#[pyo3(signature = (a = 2, b = 3))]
+fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
+    Ok((a + b).to_string())
+}
+```
+
 ## Generate a stub file
 
 And then, create an executable target in [`src/bin/stub_gen.rs`](./examples/pure/src/bin/stub_gen.rs) to generate a stub file:

--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -9,7 +9,7 @@ from enum import Enum, auto
 MY_CONSTANT: int
 class A:
     x: int
-    def __new__(cls,x:int): ...
+    def __new__(cls,x: int = 2): ...
     def show_x(self) -> None:
         ...
 
@@ -24,7 +24,7 @@ class Number(Enum):
 def ahash_dict() -> dict[str, int]:
     ...
 
-def create_a(x:int) -> A:
+def create_a(x: int = 2) -> A:
     ...
 
 def create_dict(n:int) -> dict[int, list[int]]:

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -64,16 +64,22 @@ impl A {
     }
 }
 
+struct MyInt(usize);
+impl FromPyObject<'_> for MyInt {
+    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+        Ok(Self(ob.extract::<usize>()?))
+    }
+}
 #[gen_stub_pyfunction]
 #[pyfunction]
 #[pyo3(signature = (
-    x = 2,
+    x = MyInt(2),
 ))]
 #[gen_stub(signature = (
     x: int = 2,
 ))]
-fn create_a(x: usize) -> A {
-    A { x }
+fn create_a(x: MyInt) -> A {
+    A { x: x.0 }
 }
 
 create_exception!(pure, MyError, PyRuntimeError);

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -45,6 +45,12 @@ struct A {
 #[pymethods]
 impl A {
     #[new]
+    #[pyo3(signature = (
+        x = 2,
+    ))]
+    #[gen_stub(signature = (
+        x: int = 2,
+    ))]
     fn new(x: usize) -> Self {
         Self { x }
     }
@@ -60,6 +66,12 @@ impl A {
 
 #[gen_stub_pyfunction]
 #[pyfunction]
+#[pyo3(signature = (
+    x = 2,
+))]
+#[gen_stub(signature = (
+    x: int = 2,
+))]
 fn create_a(x: usize) -> A {
     A { x }
 }

--- a/pyo3-stub-gen-derive/src/gen_stub/arg.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/arg.rs
@@ -38,7 +38,7 @@ pub fn parse_args(iter: impl IntoIterator<Item = FnArg>) -> Result<Vec<ArgInfo>>
 
 #[derive(Debug)]
 pub struct ArgInfo {
-    name: String,
+    pub name: String,
     pub r#type: Type,
 }
 

--- a/pyo3-stub-gen-derive/src/gen_stub/method.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/method.rs
@@ -112,10 +112,16 @@ impl ToTokens for MethodInfo {
         } else {
             quote! { ::pyo3_stub_gen::type_info::no_return_type_output }
         };
+        let args_tt = if specified_sig.is_some() {
+            // turn-off auto type inference when specified signature
+            quote! { &[] }
+        } else {
+            quote! { &[ #(#args),* ] }
+        };
         tokens.append_all(quote! {
             ::pyo3_stub_gen::type_info::MethodInfo {
                 name: #name,
-                args: &[ #(#args),* ],
+                args: #args_tt,
                 r#return: #ret_tt,
                 signature: #sig_tt,
                 specified_signature: #specified_sig_tt,

--- a/pyo3-stub-gen-derive/src/gen_stub/new.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/new.rs
@@ -1,4 +1,6 @@
-use super::{parse_args, parse_pyo3_attrs, quote_option, ArgInfo, Attr, Signature};
+use super::{
+    check_specified_signature, parse_args, parse_pyo3_attrs, quote_option, ArgInfo, Attr, Signature,
+};
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
@@ -8,6 +10,7 @@ use syn::{Error, ImplItemFn, Result};
 pub struct NewInfo {
     args: Vec<ArgInfo>,
     sig: Option<Signature>,
+    specified_sig: Option<String>,
 }
 
 impl NewInfo {
@@ -24,26 +27,38 @@ impl TryFrom<ImplItemFn> for NewInfo {
         let ImplItemFn { attrs, sig, .. } = item;
         let attrs = parse_pyo3_attrs(&attrs)?;
         let mut new_sig = None;
+        let mut new_specified_sig = None;
         for attr in attrs {
-            if let Attr::Signature(text_sig) = attr {
-                new_sig = Some(text_sig);
+            match attr {
+                Attr::Signature(text_sig) => new_sig = Some(text_sig),
+                Attr::SpecifiedSignature(specified_sig) => new_specified_sig = Some(specified_sig),
+                _ => {}
             }
         }
+        let args = parse_args(sig.inputs)?;
+        check_specified_signature("__new__", &new_specified_sig, &args, &new_sig)?;
         Ok(NewInfo {
-            args: parse_args(sig.inputs)?,
+            args,
             sig: new_sig,
+            specified_sig: new_specified_sig,
         })
     }
 }
 
 impl ToTokens for NewInfo {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
-        let Self { args, sig } = self;
+        let Self {
+            args,
+            sig,
+            specified_sig,
+        } = self;
         let sig_tt = quote_option(sig);
+        let specified_sig_tt = quote_option(specified_sig);
         tokens.append_all(quote! {
             ::pyo3_stub_gen::type_info::NewInfo {
                 args: &[ #(#args),* ],
                 signature: #sig_tt,
+                specified_signature: #specified_sig_tt,
             }
         })
     }

--- a/pyo3-stub-gen-derive/src/gen_stub/new.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/new.rs
@@ -54,9 +54,15 @@ impl ToTokens for NewInfo {
         } = self;
         let sig_tt = quote_option(sig);
         let specified_sig_tt = quote_option(specified_sig);
+        let args_tt = if specified_sig.is_some() {
+            // turn-off auto type inference when specified signature
+            quote! { &[] }
+        } else {
+            quote! { &[ #(#args),* ] }
+        };
         tokens.append_all(quote! {
             ::pyo3_stub_gen::type_info::NewInfo {
-                args: &[ #(#args),* ],
+                args: #args_tt,
                 signature: #sig_tt,
                 specified_signature: #specified_sig_tt,
             }

--- a/pyo3-stub-gen-derive/src/gen_stub/pyfunction.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyfunction.rs
@@ -98,11 +98,17 @@ impl ToTokens for PyFunctionInfo {
         };
         let sig_tt = quote_option(sig);
         let specified_sig_tt = quote_option(specified_sig);
+        let args_tt = if specified_sig.is_some() {
+            // turn-off auto type inference when specified signature
+            quote! { &[] }
+        } else {
+            quote! { &[ #(#args),* ] }
+        };
         let module_tt = quote_option(module);
         tokens.append_all(quote! {
             ::pyo3_stub_gen::type_info::PyFunctionInfo {
                 name: #name,
-                args: &[ #(#args),* ],
+                args: #args_tt,
                 r#return: #ret_tt,
                 doc: #doc,
                 signature: #sig_tt,

--- a/pyo3-stub-gen-derive/src/gen_stub/pymethods.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pymethods.rs
@@ -11,6 +11,23 @@ pub struct PyMethodsInfo {
     methods: Vec<MethodInfo>,
 }
 
+pub(crate) fn prune_attrs(item: &mut ItemImpl) {
+    for inner in item.items.iter_mut() {
+        if let ImplItem::Fn(item_fn) = inner {
+            item_fn.attrs = std::mem::take(&mut item_fn.attrs)
+                .into_iter()
+                .filter_map(|attr| {
+                    if attr.path().is_ident("gen_stub") {
+                        None
+                    } else {
+                        Some(attr)
+                    }
+                })
+                .collect();
+        }
+    }
+}
+
 impl TryFrom<ItemImpl> for PyMethodsInfo {
     type Error = Error;
     fn try_from(item: ItemImpl) -> Result<Self> {

--- a/pyo3-stub-gen-derive/src/gen_stub/signature.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/signature.rs
@@ -92,4 +92,16 @@ impl Signature {
         }
         None
     }
+    pub fn args_name(&self) -> Vec<String> {
+        self.args
+            .iter()
+            .filter_map(|arg| match arg {
+                SignatureArg::Ident(ident)
+                | SignatureArg::Assign(ident, _, _)
+                | SignatureArg::Args(_, ident)
+                | SignatureArg::Keywords(_, _, ident) => Some(ident.to_string()),
+                SignatureArg::Star(_) => None,
+            })
+            .collect()
+    }
 }

--- a/pyo3-stub-gen/src/generate/function.rs
+++ b/pyo3-stub-gen/src/generate/function.rs
@@ -28,7 +28,7 @@ impl From<&PyFunctionInfo> for FunctionDef {
             args: info.args.iter().map(Arg::from).collect(),
             r#return: (info.r#return)(),
             doc: info.doc,
-            signature: info.signature,
+            signature: info.specified_signature.or(info.signature),
         }
     }
 }

--- a/pyo3-stub-gen/src/generate/method.rs
+++ b/pyo3-stub-gen/src/generate/method.rs
@@ -28,7 +28,7 @@ impl From<&MethodInfo> for MethodDef {
         Self {
             name: info.name,
             args: info.args.iter().map(Arg::from).collect(),
-            signature: info.signature,
+            signature: info.specified_signature.or(info.signature),
             r#return: (info.r#return)(),
             doc: info.doc,
             is_static: info.is_static,

--- a/pyo3-stub-gen/src/generate/new.rs
+++ b/pyo3-stub-gen/src/generate/new.rs
@@ -22,7 +22,7 @@ impl From<&NewInfo> for NewDef {
     fn from(info: &NewInfo) -> Self {
         Self {
             args: info.args.iter().map(Arg::from).collect(),
-            signature: info.signature,
+            signature: info.specified_signature.or(info.signature),
         }
     }
 }

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -48,6 +48,7 @@ pub struct MethodInfo {
     pub args: &'static [ArgInfo],
     pub r#return: fn() -> TypeInfo,
     pub signature: Option<&'static str>,
+    pub specified_signature: Option<&'static str>,
     pub doc: &'static str,
     pub is_static: bool,
     pub is_class: bool,
@@ -65,6 +66,7 @@ pub struct MemberInfo {
 pub struct NewInfo {
     pub args: &'static [ArgInfo],
     pub signature: Option<&'static str>,
+    pub specified_signature: Option<&'static str>,
 }
 
 /// Info of `#[pymethod]`
@@ -124,6 +126,7 @@ pub struct PyFunctionInfo {
     pub r#return: fn() -> TypeInfo,
     pub doc: &'static str,
     pub signature: Option<&'static str>,
+    pub specified_signature: Option<&'static str>,
     pub module: Option<&'static str>,
 }
 


### PR DESCRIPTION
Happy new year!

In some cases, we want to mannually specify the signature in stub files, yet I found both `pyo3`'s signature information and `pyo3-stub-gen`'s framework can not do that requirement.
In this PR, I introduced `#[gen_stub()]` attributes, so that we can let user to specify the signature by `#[gen_stub(signature = (xxx))]`. And the `#[gen_stub()]` can be futhur extended to support more arguments.

Here is the example of usage,
In `pymethods`: https://github.com/zao111222333/pyo3-stub-gen/blob/3e84b22d70de255b70377de02c36d96653ad1fe0/examples/pure/src/lib.rs#L51-L53
In `pyfunction`: https://github.com/zao111222333/pyo3-stub-gen/blob/3e84b22d70de255b70377de02c36d96653ad1fe0/examples/pure/src/lib.rs#L72-L74

And you can see the output in stub file,
In `pymethods`: https://github.com/zao111222333/pyo3-stub-gen/blob/3e84b22d70de255b70377de02c36d96653ad1fe0/examples/pure/pure.pyi#L12
In `pyfunction`: https://github.com/zao111222333/pyo3-stub-gen/blob/3e84b22d70de255b70377de02c36d96653ad1fe0/examples/pure/pure.pyi#L27

Hope you like that :)