### PR TITLE
fix: builtin bytes type missing

### DIFF
--- a/pyo3-stub-gen/src/stub_type/builtins.rs
+++ b/pyo3-stub-gen/src/stub_type/builtins.rs
@@ -59,6 +59,7 @@ impl_builtin!(String, "str");
 impl_builtin!(OsString, "str");
 impl_builtin!(Cow<'_, str>, "str");
 impl_builtin!(Cow<'_, OsStr>, "str");
+impl_builtin!(Cow<'_, [u8]>, "bytes");
 
 impl PyStubType for PathBuf {
     fn type_output() -> TypeInfo {


### PR DESCRIPTION
According to pyo3's [documentation](https://pyo3.rs/v0.23.3/conversions/tables.html#returning-rust-values-to-python), `Cow<[u8]>` in Rust is Python's `bytes` type, but this mapping is currently not implemented in the crate.