### PR TITLE
Using pyo3's signature information to generate python's defualt value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "mixed"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "env_logger",
  "pyo3",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "mixed_sub"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "env_logger",
  "pyo3",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "mixed_sub_multiple"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "env_logger",
  "pyo3",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "pure"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "env_logger",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen-derive"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "insta",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [workspace]
 members = [
-    "pyo3-stub-gen",
-    "pyo3-stub-gen-derive",
-    "examples/pure",
-    "examples/mixed",
-    "examples/mixed_sub",
-    "examples/mixed_sub_multiple",
+  "pyo3-stub-gen",
+  "pyo3-stub-gen-derive",
+  "examples/pure",
+  "examples/mixed",
+  "examples/mixed_sub",
+  "examples/mixed_sub_multiple",
 ]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 
 description = "Stub file (*.pyi) generator for PyO3"

--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -24,7 +24,7 @@ class Number(Enum):
 def ahash_dict() -> dict[str, int]:
     ...
 
-def create_a(x:int) -> A:
+def create_a(x:int=2) -> A:
     ...
 
 def create_dict(n:int) -> dict[int, list[int]]:

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -60,6 +60,7 @@ impl A {
 
 #[gen_stub_pyfunction]
 #[pyfunction]
+#[pyo3(signature = (x = 2))]
 fn create_a(x: usize) -> A {
     A { x }
 }

--- a/pyo3-stub-gen-derive/src/gen_stub/arg.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/arg.rs
@@ -1,6 +1,4 @@
-use super::remove_lifetime;
-use proc_macro2::TokenStream as TokenStream2;
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::ToTokens;
 use syn::{
     spanned::Spanned, FnArg, GenericArgument, PatType, PathArguments, Result, Type, TypePath,
 };
@@ -38,7 +36,7 @@ pub fn parse_args(iter: impl IntoIterator<Item = FnArg>) -> Result<Vec<ArgInfo>>
 
 #[derive(Debug)]
 pub struct ArgInfo {
-    name: String,
+    pub name: String,
     pub r#type: Type,
 }
 
@@ -54,19 +52,5 @@ impl TryFrom<FnArg> for ArgInfo {
             }
         }
         Err(syn::Error::new(span, "Expected typed argument"))
-    }
-}
-
-impl ToTokens for ArgInfo {
-    fn to_tokens(&self, tokens: &mut TokenStream2) {
-        let Self { name, r#type: ty } = self;
-        let mut ty = ty.clone();
-        remove_lifetime(&mut ty);
-        tokens.append_all(quote! {
-            ::pyo3_stub_gen::type_info::ArgInfo {
-                name: #name,
-                r#type: <#ty as ::pyo3_stub_gen::PyStubType>::type_input
-            }
-        });
     }
 }

--- a/pyo3-stub-gen-derive/src/gen_stub/method.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/method.rs
@@ -1,6 +1,6 @@
 use super::{
-    arg::parse_args, escape_return_type, extract_documents, parse_pyo3_attrs, quote_option,
-    ArgInfo, Attr, Signature,
+    arg::parse_args, escape_return_type, extract_documents, parse_pyo3_attrs, ArgInfo,
+    ArgsWithSignature, Attr, Signature,
 };
 
 use proc_macro2::TokenStream as TokenStream2;
@@ -98,7 +98,7 @@ impl ToTokens for MethodInfo {
             is_class,
             is_static,
         } = self;
-        let sig_tt = quote_option(sig);
+        let args_with_sig = ArgsWithSignature { args, sig };
         let ret_tt = if let Some(ret) = ret {
             quote! { <#ret as pyo3_stub_gen::PyStubType>::type_output }
         } else {
@@ -107,9 +107,8 @@ impl ToTokens for MethodInfo {
         tokens.append_all(quote! {
             ::pyo3_stub_gen::type_info::MethodInfo {
                 name: #name,
-                args: &[ #(#args),* ],
+                args: #args_with_sig,
                 r#return: #ret_tt,
-                signature: #sig_tt,
                 doc: #doc,
                 is_static: #is_static,
                 is_class: #is_class,

--- a/pyo3-stub-gen-derive/src/gen_stub/new.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/new.rs
@@ -1,4 +1,4 @@
-use super::{parse_args, parse_pyo3_attrs, quote_option, ArgInfo, Attr, Signature};
+use super::{parse_args, parse_pyo3_attrs, ArgInfo, ArgsWithSignature, Attr, Signature};
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
@@ -39,11 +39,10 @@ impl TryFrom<ImplItemFn> for NewInfo {
 impl ToTokens for NewInfo {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
         let Self { args, sig } = self;
-        let sig_tt = quote_option(sig);
+        let args_with_sig = ArgsWithSignature { args, sig };
         tokens.append_all(quote! {
             ::pyo3_stub_gen::type_info::NewInfo {
-                args: &[ #(#args),* ],
-                signature: #sig_tt,
+                args: #args_with_sig,
             }
         })
     }

--- a/pyo3-stub-gen-derive/src/gen_stub/pyfunction.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyfunction.rs
@@ -7,7 +7,7 @@ use syn::{
 
 use super::{
     escape_return_type, extract_documents, parse_args, parse_pyo3_attrs, quote_option, ArgInfo,
-    Attr, Signature,
+    ArgsWithSignature, Attr, Signature,
 };
 
 pub struct PyFunctionInfo {
@@ -88,15 +88,15 @@ impl ToTokens for PyFunctionInfo {
         } else {
             quote! { ::pyo3_stub_gen::type_info::no_return_type_output }
         };
-        let sig_tt = quote_option(sig);
+        // let sig_tt = quote_option(sig);
         let module_tt = quote_option(module);
+        let args_with_sig = ArgsWithSignature { args, sig };
         tokens.append_all(quote! {
             ::pyo3_stub_gen::type_info::PyFunctionInfo {
                 name: #name,
-                args: &[ #(#args),* ],
+                args: #args_with_sig,
                 r#return: #ret_tt,
                 doc: #doc,
-                signature: #sig_tt,
                 module: #module_tt,
             }
         })

--- a/pyo3-stub-gen-derive/src/gen_stub/signature.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/signature.rs
@@ -67,7 +67,7 @@ pub struct ArgsWithSignature<'a> {
     pub sig: &'a Option<Signature>,
 }
 
-impl<'a> ToTokens for ArgsWithSignature<'a> {
+impl ToTokens for ArgsWithSignature<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
         let arg_infos: Vec<TokenStream2> = if let Some(sig) = self.sig {
             // record all Type information from rust's args

--- a/pyo3-stub-gen-derive/src/gen_stub/signature.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/signature.rs
@@ -105,10 +105,11 @@ impl ToTokens for ArgsWithSignature<'_> {
                                         ::pyo3::prepare_freethreaded_python();
                                         ::pyo3::Python::with_gil(|py| -> String {
                                             let v: #ty = #value;
-                                            <#ty as ::pyo3::IntoPyObject>::into_pyobject(v, py)
-                                                .map_err(|_| ())
-                                                .and_then(|py_obj| ::pyo3_stub_gen::util::fmt_py_obj(&py_obj))
-                                                .unwrap_or("...".to_owned())
+                                            if let Ok(py_obj) = <#ty as ::pyo3::IntoPyObject>::into_pyobject(v, py) {
+                                                ::pyo3_stub_gen::util::fmt_py_obj(&py_obj)
+                                            } else {
+                                                "...".to_owned()
+                                            }
                                         })
                                     });
                                     &DEFAULT

--- a/pyo3-stub-gen-derive/src/gen_stub/signature.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/signature.rs
@@ -102,12 +102,13 @@ impl ToTokens for ArgsWithSignature<'_> {
                             signature: Some(pyo3_stub_gen::type_info::SignatureArg::Assign{
                                 default: {
                                     static DEFAULT: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
-                                        pyo3::prepare_freethreaded_python();
+                                        ::pyo3::prepare_freethreaded_python();
                                         ::pyo3::Python::with_gil(|py| -> String {
                                             let v: #ty = #value;
                                             <#ty as ::pyo3::IntoPyObject>::into_pyobject(v, py)
-                                                .unwrap()
-                                                .to_string()
+                                                .map_err(|_| ())
+                                                .and_then(|py_obj| ::pyo3_stub_gen::util::fmt_py_obj(&py_obj))
+                                                .unwrap_or("...".to_owned())
                                         })
                                     });
                                     &DEFAULT

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -22,7 +22,7 @@ serde.workspace = true
 toml.workspace = true
 
 [dependencies.pyo3-stub-gen-derive]
-version = "0.6.3"
+version = "0.7.0"
 path = "../pyo3-stub-gen-derive"
 
 [features]

--- a/pyo3-stub-gen/src/generate/arg.rs
+++ b/pyo3-stub-gen/src/generate/arg.rs
@@ -5,6 +5,7 @@ use std::{collections::HashSet, fmt};
 pub struct Arg {
     pub name: &'static str,
     pub r#type: TypeInfo,
+    pub signature: Option<SignatureArg>,
 }
 
 impl Import for Arg {
@@ -18,12 +19,26 @@ impl From<&ArgInfo> for Arg {
         Self {
             name: info.name,
             r#type: (info.r#type)(),
+            signature: info.signature.clone(),
         }
     }
 }
 
 impl fmt::Display for Arg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}:{}", self.name, self.r#type)
+        if let Some(signature) = &self.signature {
+            match signature {
+                SignatureArg::Ident => write!(f, "{}:{}", self.name, self.r#type),
+                SignatureArg::Assign { default } => {
+                    let default: &String = &*default;
+                    write!(f, "{}:{}={}", self.name, self.r#type, default)
+                }
+                SignatureArg::Star => write!(f, "*"),
+                SignatureArg::Args => write!(f, "*{}", self.name),
+                SignatureArg::Keywords => write!(f, "**{}", self.name),
+            }
+        } else {
+            write!(f, "{}:{}", self.name, self.r#type)
+        }
     }
 }

--- a/pyo3-stub-gen/src/generate/arg.rs
+++ b/pyo3-stub-gen/src/generate/arg.rs
@@ -30,7 +30,7 @@ impl fmt::Display for Arg {
             match signature {
                 SignatureArg::Ident => write!(f, "{}:{}", self.name, self.r#type),
                 SignatureArg::Assign { default } => {
-                    let default: &String = &*default;
+                    let default: &String = default;
                     write!(f, "{}:{}={}", self.name, self.r#type, default)
                 }
                 SignatureArg::Star => write!(f, "*"),

--- a/pyo3-stub-gen/src/generate/function.rs
+++ b/pyo3-stub-gen/src/generate/function.rs
@@ -7,7 +7,6 @@ pub struct FunctionDef {
     pub name: &'static str,
     pub args: Vec<Arg>,
     pub r#return: TypeInfo,
-    pub signature: Option<&'static str>,
     pub doc: &'static str,
 }
 
@@ -28,7 +27,7 @@ impl From<&PyFunctionInfo> for FunctionDef {
             args: info.args.iter().map(Arg::from).collect(),
             r#return: (info.r#return)(),
             doc: info.doc,
-            signature: info.signature,
+            // signature: info.signature,
         }
     }
 }
@@ -36,14 +35,10 @@ impl From<&PyFunctionInfo> for FunctionDef {
 impl fmt::Display for FunctionDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "def {}(", self.name)?;
-        if let Some(sig) = self.signature {
-            write!(f, "{}", sig)?;
-        } else {
-            for (i, arg) in self.args.iter().enumerate() {
-                write!(f, "{}", arg)?;
-                if i != self.args.len() - 1 {
-                    write!(f, ",")?;
-                }
+        for (i, arg) in self.args.iter().enumerate() {
+            write!(f, "{}", arg)?;
+            if i != self.args.len() - 1 {
+                write!(f, ", ")?;
             }
         }
         writeln!(f, ") -> {}:", self.r#return)?;

--- a/pyo3-stub-gen/src/generate/function.rs
+++ b/pyo3-stub-gen/src/generate/function.rs
@@ -27,7 +27,6 @@ impl From<&PyFunctionInfo> for FunctionDef {
             args: info.args.iter().map(Arg::from).collect(),
             r#return: (info.r#return)(),
             doc: info.doc,
-            // signature: info.signature,
         }
     }
 }

--- a/pyo3-stub-gen/src/generate/method.rs
+++ b/pyo3-stub-gen/src/generate/method.rs
@@ -6,7 +6,6 @@ use std::{collections::HashSet, fmt};
 pub struct MethodDef {
     pub name: &'static str,
     pub args: Vec<Arg>,
-    pub signature: Option<&'static str>,
     pub r#return: TypeInfo,
     pub doc: &'static str,
     pub is_static: bool,
@@ -28,7 +27,6 @@ impl From<&MethodInfo> for MethodDef {
         Self {
             name: info.name,
             args: info.args.iter().map(Arg::from).collect(),
-            signature: info.signature,
             r#return: (info.r#return)(),
             doc: info.doc,
             is_static: info.is_static,
@@ -52,19 +50,12 @@ impl fmt::Display for MethodDef {
             write!(f, "{indent}def {}(self", self.name)?;
             needs_comma = true;
         }
-        if let Some(signature) = self.signature {
+        for arg in &self.args {
             if needs_comma {
                 write!(f, ", ")?;
             }
-            write!(f, "{}", signature)?;
-        } else {
-            for arg in &self.args {
-                if needs_comma {
-                    write!(f, ", ")?;
-                }
-                write!(f, "{}", arg)?;
-                needs_comma = true;
-            }
+            write!(f, "{}", arg)?;
+            needs_comma = true;
         }
         writeln!(f, ") -> {}:", self.r#return)?;
 

--- a/pyo3-stub-gen/src/generate/new.rs
+++ b/pyo3-stub-gen/src/generate/new.rs
@@ -5,7 +5,6 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq)]
 pub struct NewDef {
     pub args: Vec<Arg>,
-    pub signature: Option<&'static str>,
 }
 
 impl Import for NewDef {
@@ -22,7 +21,6 @@ impl From<&NewInfo> for NewDef {
     fn from(info: &NewInfo) -> Self {
         Self {
             args: info.args.iter().map(Arg::from).collect(),
-            signature: info.signature,
         }
     }
 }
@@ -31,15 +29,10 @@ impl fmt::Display for NewDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let indent = indent();
         write!(f, "{indent}def __new__(cls,")?;
-        if let Some(signature) = self.signature {
-            let joined = signature.replace('\n', " ");
-            write!(f, "{}", joined)?;
-        } else {
-            for (n, arg) in self.args.iter().enumerate() {
-                write!(f, "{}", arg)?;
-                if n != self.args.len() - 1 {
-                    write!(f, ", ")?;
-                }
+        for (n, arg) in self.args.iter().enumerate() {
+            write!(f, "{}", arg)?;
+            if n != self.args.len() - 1 {
+                write!(f, ", ")?;
             }
         }
         writeln!(f, "): ...")?;

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -117,8 +117,7 @@
 //!
 //! let method = MethodDef {
 //!     name: "foo",
-//!     args: vec![Arg { name: "x", r#type: TypeInfo::builtin("int") }],
-//!     signature: None,
+//!     args: vec![Arg { name: "x", r#type: TypeInfo::builtin("int"), signature: None, }],
 //!     r#return: TypeInfo::builtin("int"),
 //!     doc: "This is a foo method.",
 //!     is_static: false,

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -152,6 +152,7 @@ pub mod generate;
 pub mod pyproject;
 mod stub_type;
 pub mod type_info;
+pub mod util;
 
 pub use generate::StubInfo;
 pub use stub_type::{PyStubType, TypeInfo};

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -39,6 +39,31 @@ pub fn no_return_type_output() -> TypeInfo {
 pub struct ArgInfo {
     pub name: &'static str,
     pub r#type: fn() -> TypeInfo,
+    pub signature: Option<SignatureArg>,
+}
+#[derive(Debug, Clone)]
+pub enum SignatureArg {
+    Ident,
+    Assign {
+        default: &'static std::sync::LazyLock<String>,
+    },
+    Star,
+    Args,
+    Keywords,
+}
+
+impl PartialEq for SignatureArg {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Assign { default: l_default }, Self::Assign { default: r_default }) => {
+                let l_default: &String = &*l_default;
+                let r_default: &String = &*r_default;
+                l_default.eq(r_default)
+            }
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
 }
 
 /// Info of usual method appears in `#[pymethod]`
@@ -47,7 +72,6 @@ pub struct MethodInfo {
     pub name: &'static str,
     pub args: &'static [ArgInfo],
     pub r#return: fn() -> TypeInfo,
-    pub signature: Option<&'static str>,
     pub doc: &'static str,
     pub is_static: bool,
     pub is_class: bool,
@@ -64,7 +88,6 @@ pub struct MemberInfo {
 #[derive(Debug)]
 pub struct NewInfo {
     pub args: &'static [ArgInfo],
-    pub signature: Option<&'static str>,
 }
 
 /// Info of `#[pymethod]`
@@ -123,7 +146,6 @@ pub struct PyFunctionInfo {
     pub args: &'static [ArgInfo],
     pub r#return: fn() -> TypeInfo,
     pub doc: &'static str,
-    pub signature: Option<&'static str>,
     pub module: Option<&'static str>,
 }
 

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -57,8 +57,8 @@ impl PartialEq for SignatureArg {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Assign { default: l_default }, Self::Assign { default: r_default }) => {
-                let l_default: &String = &*l_default;
-                let r_default: &String = &*r_default;
+                let l_default: &String = l_default;
+                let r_default: &String = r_default;
                 l_default.eq(r_default)
             }
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),

--- a/pyo3-stub-gen/src/util.rs
+++ b/pyo3-stub-gen/src/util.rs
@@ -1,0 +1,126 @@
+use pyo3::{prelude::*, types::*};
+
+/// Reference to https://github.com/Jij-Inc/serde-pyobject/blob/5916fefc5b7f0e096ed13869dc41b36ad6f62dc2/src/de.rs#L309-L333
+pub fn fmt_py_obj(any: &Bound<'_, PyAny>) -> Result<String, ()> {
+    if any.is_instance_of::<PyDict>() {
+        return any.downcast::<PyDict>().map_err(|_| ()).and_then(|dict| {
+            dict.into_iter()
+                .map(|(k, v)| {
+                    if let (Ok(k), Ok(v)) = (fmt_py_obj(&k), fmt_py_obj(&v)) {
+                        Ok(format!("{k}: {v}"))
+                    } else {
+                        Err(())
+                    }
+                })
+                .collect::<Result<Vec<String>, ()>>()
+                .map(|kv_list| format!("{{{}}}", kv_list.join(", ")))
+        });
+    }
+    if any.is_instance_of::<PyList>() {
+        return any.downcast::<PyList>().map_err(|_| ()).and_then(|list| {
+            list.into_iter()
+                .map(|v| fmt_py_obj(&v))
+                .collect::<Result<Vec<String>, ()>>()
+                .map(|v_list| format!("[{}]", v_list.join(", ")))
+        });
+    }
+    if any.is_instance_of::<PyTuple>() {
+        return any.downcast::<PyTuple>().map_err(|_| ()).and_then(|list| {
+            list.into_iter()
+                .map(|v| fmt_py_obj(&v))
+                .collect::<Result<Vec<String>, ()>>()
+                .map(|v_list| format!("({})", v_list.join(", ")))
+        });
+    }
+    if any.is_instance_of::<PyString>() {
+        return any
+            .extract::<String>()
+            .map_err(|_| ())
+            .map(|s| format!("\"{s}\""));
+    }
+    if any.is_instance_of::<PyBool>() {
+        // must be match before PyLong
+        return any
+            .extract::<bool>()
+            .map_err(|_| ())
+            .map(|b| if b { "True" } else { "False" }.to_owned());
+    }
+    if any.is_instance_of::<PyInt>() {
+        return any.extract::<i64>().map_err(|_| ()).map(|n| n.to_string());
+    }
+    if any.is_instance_of::<PyFloat>() {
+        return any.extract::<f64>().map_err(|_| ()).map(|f| f.to_string());
+    }
+    if any.is_none() {
+        return Ok("None".to_owned());
+    }
+    Err(())
+}
+
+#[cfg(test)]
+mod test {
+    use pyo3::IntoPyObjectExt;
+
+    use super::*;
+    #[pyclass]
+    #[derive(Debug)]
+    struct A {}
+    #[test]
+    fn test_fmt_dict() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let dict = PyDict::new(py);
+            _ = dict.set_item("k1", "v1");
+            _ = dict.set_item("k2", 2);
+            assert_eq!(
+                Ok("{\"k1\": \"v1\", \"k2\": 2}".to_owned()),
+                fmt_py_obj(&dict)
+            );
+            // class A variable can not be formatted
+            _ = dict.set_item("k3", A {});
+            assert_eq!(Err(()), fmt_py_obj(&dict));
+        })
+    }
+    #[test]
+    fn test_fmt_list() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let list = PyList::new(py, [1, 2]).unwrap();
+            assert_eq!(Ok("[1, 2]".to_owned()), fmt_py_obj(&list));
+            // class A variable can not be formatted
+            let list = PyList::new(py, [A {}, A {}]).unwrap();
+            assert_eq!(Err(()), fmt_py_obj(&list));
+        })
+    }
+    #[test]
+    fn test_fmt_tuple() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let tuple = PyTuple::new(py, [1, 2]).unwrap();
+            assert_eq!(Ok("(1, 2)".to_owned()), fmt_py_obj(&tuple));
+            // class A variable can not be formatted
+            let tuple = PyTuple::new(py, [A {}]).unwrap();
+            assert_eq!(Err(()), fmt_py_obj(&tuple));
+        })
+    }
+    #[test]
+    fn test_fmt_other() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            // str
+            assert_eq!(Ok("\"123\"".to_owned()), fmt_py_obj(&"123".into_bound_py_any(py).unwrap()));
+            // bool
+            assert_eq!(Ok("True".to_owned()), fmt_py_obj(&true.into_bound_py_any(py).unwrap()));
+            assert_eq!(Ok("False".to_owned()), fmt_py_obj(&false.into_bound_py_any(py).unwrap()));
+            // int
+            assert_eq!(Ok("123".to_owned()), fmt_py_obj(&123.into_bound_py_any(py).unwrap()));
+            // float
+            assert_eq!(Ok("1.23".to_owned()), fmt_py_obj(&1.23.into_bound_py_any(py).unwrap()));
+            // None
+            let none: Option<usize>  = None;
+            assert_eq!(Ok("None".to_owned()), fmt_py_obj(&none.into_bound_py_any(py).unwrap()));
+            // class A variable can not be formatted
+            assert_eq!(Err(()), fmt_py_obj(&A{}.into_bound_py_any(py).unwrap()));
+        })
+    }
+}

--- a/pyo3-stub-gen/src/util.rs
+++ b/pyo3-stub-gen/src/util.rs
@@ -1,61 +1,49 @@
 use pyo3::{prelude::*, types::*};
 
-/// Reference to <https://github.com/Jij-Inc/serde-pyobject/blob/5916fefc5b7f0e096ed13869dc41b36ad6f62dc2/src/de.rs#L309-L333>
-#[allow(clippy::result_unit_err)]
-pub fn fmt_py_obj(any: &Bound<'_, PyAny>) -> Result<String, ()> {
-    if any.is_instance_of::<PyDict>() {
-        return any.downcast::<PyDict>().map_err(|_| ()).and_then(|dict| {
-            dict.into_iter()
-                .map(|(k, v)| {
-                    if let (Ok(k), Ok(v)) = (fmt_py_obj(&k), fmt_py_obj(&v)) {
-                        Ok(format!("{k}: {v}"))
-                    } else {
-                        Err(())
-                    }
+pub fn fmt_py_obj(any: &Bound<'_, PyAny>) -> String {
+    fn all_builtin_types(any: &Bound<'_, PyAny>) -> bool {
+        if any.is_instance_of::<PyString>()
+            || any.is_instance_of::<PyBool>()
+            || any.is_instance_of::<PyInt>()
+            || any.is_instance_of::<PyFloat>()
+            || any.is_none()
+        {
+            return true;
+        }
+        if any.is_instance_of::<PyDict>() {
+            return any
+                .downcast::<PyDict>()
+                .map(|dict| {
+                    dict.into_iter()
+                        .all(|(k, v)| all_builtin_types(&k) && all_builtin_types(&v))
                 })
-                .collect::<Result<Vec<String>, ()>>()
-                .map(|kv_list| format!("{{{}}}", kv_list.join(", ")))
-        });
+                .unwrap_or(false);
+        }
+        if any.is_instance_of::<PyList>() {
+            return any
+                .downcast::<PyList>()
+                .map(|list| list.into_iter().all(|v| all_builtin_types(&v)))
+                .unwrap_or(false);
+        }
+        if any.is_instance_of::<PyTuple>() {
+            return any
+                .downcast::<PyTuple>()
+                .map(|list| list.into_iter().all(|v| all_builtin_types(&v)))
+                .unwrap_or(false);
+        }
+        false
     }
-    if any.is_instance_of::<PyList>() {
-        return any.downcast::<PyList>().map_err(|_| ()).and_then(|list| {
-            list.into_iter()
-                .map(|v| fmt_py_obj(&v))
-                .collect::<Result<Vec<String>, ()>>()
-                .map(|v_list| format!("[{}]", v_list.join(", ")))
-        });
+    if all_builtin_types(any) {
+        // `to_string` for `PyString` will lose quotes
+        if any.is_instance_of::<PyString>() {
+            if let Ok(s) = any.extract::<String>() {
+                return format!("'{s}'");
+            }
+        } else {
+            return any.to_string();
+        }
     }
-    if any.is_instance_of::<PyTuple>() {
-        return any.downcast::<PyTuple>().map_err(|_| ()).and_then(|list| {
-            list.into_iter()
-                .map(|v| fmt_py_obj(&v))
-                .collect::<Result<Vec<String>, ()>>()
-                .map(|v_list| format!("({})", v_list.join(", ")))
-        });
-    }
-    if any.is_instance_of::<PyString>() {
-        return any
-            .extract::<String>()
-            .map_err(|_| ())
-            .map(|s| format!("\"{s}\""));
-    }
-    if any.is_instance_of::<PyBool>() {
-        // must be match before PyLong
-        return any
-            .extract::<bool>()
-            .map_err(|_| ())
-            .map(|b| if b { "True" } else { "False" }.to_owned());
-    }
-    if any.is_instance_of::<PyInt>() {
-        return any.extract::<i64>().map_err(|_| ()).map(|n| n.to_string());
-    }
-    if any.is_instance_of::<PyFloat>() {
-        return any.extract::<f64>().map_err(|_| ()).map(|f| f.to_string());
-    }
-    if any.is_none() {
-        return Ok("None".to_owned());
-    }
-    Err(())
+    "...".to_owned()
 }
 
 #[cfg(test)]
@@ -73,13 +61,10 @@ mod test {
             let dict = PyDict::new(py);
             _ = dict.set_item("k1", "v1");
             _ = dict.set_item("k2", 2);
-            assert_eq!(
-                Ok("{\"k1\": \"v1\", \"k2\": 2}".to_owned()),
-                fmt_py_obj(&dict)
-            );
+            assert_eq!("{'k1': 'v1', 'k2': 2}", fmt_py_obj(&dict));
             // class A variable can not be formatted
             _ = dict.set_item("k3", A {});
-            assert_eq!(Err(()), fmt_py_obj(&dict));
+            assert_eq!("...", fmt_py_obj(&dict));
         })
     }
     #[test]
@@ -87,10 +72,10 @@ mod test {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|py| {
             let list = PyList::new(py, [1, 2]).unwrap();
-            assert_eq!(Ok("[1, 2]".to_owned()), fmt_py_obj(&list));
+            assert_eq!("[1, 2]", fmt_py_obj(&list));
             // class A variable can not be formatted
             let list = PyList::new(py, [A {}, A {}]).unwrap();
-            assert_eq!(Err(()), fmt_py_obj(&list));
+            assert_eq!("...", fmt_py_obj(&list));
         })
     }
     #[test]
@@ -98,10 +83,12 @@ mod test {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|py| {
             let tuple = PyTuple::new(py, [1, 2]).unwrap();
-            assert_eq!(Ok("(1, 2)".to_owned()), fmt_py_obj(&tuple));
+            assert_eq!("(1, 2)", fmt_py_obj(&tuple));
+            let tuple = PyTuple::new(py, [1]).unwrap();
+            assert_eq!("(1,)", fmt_py_obj(&tuple));
             // class A variable can not be formatted
             let tuple = PyTuple::new(py, [A {}]).unwrap();
-            assert_eq!(Err(()), fmt_py_obj(&tuple));
+            assert_eq!("...", fmt_py_obj(&tuple));
         })
     }
     #[test]
@@ -109,37 +96,19 @@ mod test {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|py| {
             // str
-            assert_eq!(
-                Ok("\"123\"".to_owned()),
-                fmt_py_obj(&"123".into_bound_py_any(py).unwrap())
-            );
+            assert_eq!("'123'", fmt_py_obj(&"123".into_bound_py_any(py).unwrap()));
             // bool
-            assert_eq!(
-                Ok("True".to_owned()),
-                fmt_py_obj(&true.into_bound_py_any(py).unwrap())
-            );
-            assert_eq!(
-                Ok("False".to_owned()),
-                fmt_py_obj(&false.into_bound_py_any(py).unwrap())
-            );
+            assert_eq!("True", fmt_py_obj(&true.into_bound_py_any(py).unwrap()));
+            assert_eq!("False", fmt_py_obj(&false.into_bound_py_any(py).unwrap()));
             // int
-            assert_eq!(
-                Ok("123".to_owned()),
-                fmt_py_obj(&123.into_bound_py_any(py).unwrap())
-            );
+            assert_eq!("123", fmt_py_obj(&123.into_bound_py_any(py).unwrap()));
             // float
-            assert_eq!(
-                Ok("1.23".to_owned()),
-                fmt_py_obj(&1.23.into_bound_py_any(py).unwrap())
-            );
+            assert_eq!("1.23", fmt_py_obj(&1.23.into_bound_py_any(py).unwrap()));
             // None
             let none: Option<usize> = None;
-            assert_eq!(
-                Ok("None".to_owned()),
-                fmt_py_obj(&none.into_bound_py_any(py).unwrap())
-            );
+            assert_eq!("None", fmt_py_obj(&none.into_bound_py_any(py).unwrap()));
             // class A variable can not be formatted
-            assert_eq!(Err(()), fmt_py_obj(&A {}.into_bound_py_any(py).unwrap()));
+            assert_eq!("...", fmt_py_obj(&A {}.into_bound_py_any(py).unwrap()));
         })
     }
 }

--- a/pyo3-stub-gen/src/util.rs
+++ b/pyo3-stub-gen/src/util.rs
@@ -1,6 +1,7 @@
 use pyo3::{prelude::*, types::*};
 
-/// Reference to https://github.com/Jij-Inc/serde-pyobject/blob/5916fefc5b7f0e096ed13869dc41b36ad6f62dc2/src/de.rs#L309-L333
+/// Reference to <https://github.com/Jij-Inc/serde-pyobject/blob/5916fefc5b7f0e096ed13869dc41b36ad6f62dc2/src/de.rs#L309-L333>
+#[allow(clippy::result_unit_err)]
 pub fn fmt_py_obj(any: &Bound<'_, PyAny>) -> Result<String, ()> {
     if any.is_instance_of::<PyDict>() {
         return any.downcast::<PyDict>().map_err(|_| ()).and_then(|dict| {
@@ -108,19 +109,37 @@ mod test {
         pyo3::prepare_freethreaded_python();
         Python::with_gil(|py| {
             // str
-            assert_eq!(Ok("\"123\"".to_owned()), fmt_py_obj(&"123".into_bound_py_any(py).unwrap()));
+            assert_eq!(
+                Ok("\"123\"".to_owned()),
+                fmt_py_obj(&"123".into_bound_py_any(py).unwrap())
+            );
             // bool
-            assert_eq!(Ok("True".to_owned()), fmt_py_obj(&true.into_bound_py_any(py).unwrap()));
-            assert_eq!(Ok("False".to_owned()), fmt_py_obj(&false.into_bound_py_any(py).unwrap()));
+            assert_eq!(
+                Ok("True".to_owned()),
+                fmt_py_obj(&true.into_bound_py_any(py).unwrap())
+            );
+            assert_eq!(
+                Ok("False".to_owned()),
+                fmt_py_obj(&false.into_bound_py_any(py).unwrap())
+            );
             // int
-            assert_eq!(Ok("123".to_owned()), fmt_py_obj(&123.into_bound_py_any(py).unwrap()));
+            assert_eq!(
+                Ok("123".to_owned()),
+                fmt_py_obj(&123.into_bound_py_any(py).unwrap())
+            );
             // float
-            assert_eq!(Ok("1.23".to_owned()), fmt_py_obj(&1.23.into_bound_py_any(py).unwrap()));
+            assert_eq!(
+                Ok("1.23".to_owned()),
+                fmt_py_obj(&1.23.into_bound_py_any(py).unwrap())
+            );
             // None
-            let none: Option<usize>  = None;
-            assert_eq!(Ok("None".to_owned()), fmt_py_obj(&none.into_bound_py_any(py).unwrap()));
+            let none: Option<usize> = None;
+            assert_eq!(
+                Ok("None".to_owned()),
+                fmt_py_obj(&none.into_bound_py_any(py).unwrap())
+            );
             // class A variable can not be formatted
-            assert_eq!(Err(()), fmt_py_obj(&A{}.into_bound_py_any(py).unwrap()));
+            assert_eq!(Err(()), fmt_py_obj(&A {}.into_bound_py_any(py).unwrap()));
         })
     }
 }


### PR DESCRIPTION
Hi everyone,
I want to improve the function signature when pyo3's signature is specified. 
Let me use an example to show what did I do, for the following rust function:

```rust
/// `result=(a * b) + c`,
/// `b` and `c` has defualt values
#[gen_stub_pyfunction]
#[pyfunction]
#[pyo3(signature = (a, b = vec![1,2], c = 2 ))]
fn mul_add_vec(a: usize, b: Vec<usize>, c: usize) -> Vec<usize> {
    b.into_iter().map(|b| a * b + c).collect()
}
```
Original output
```python
def mul_add_vec(a: ..., b: ... = ..., c: ... = ...) -> list[int]:
    ...
```
Now
```python
def mul_add_vec(a:int, b:typing.Sequence[int]=[1, 2], c:int=2) -> list[int]:
    ...
```
## My approach:
For instance, how to infer python's `[1, 2]` from rust's `vec![1,2]`?
To summary, I use `pyo3::IntoPyObject::into_pyobject` to get the python object converted from `vec![1,2]`, then call `to_string` to get the python object's value.

More deltails:
+ The convertion is now static, so I use `std::sync::LazyLock`, see [here](
https://github.com/zao111222333/pyo3-stub-gen/blob/56f7af96985c6909265f13766844363710da663f/pyo3-stub-gen-derive/src/gen_stub/signature.rs#L103-L113)
+ In `pyo3-stub-gen`, I merge the signature information into each `ArgInfo`, see [here](https://github.com/zao111222333/pyo3-stub-gen/blob/56f7af96985c6909265f13766844363710da663f/pyo3-stub-gen/src/generate/arg.rs#L8)