### PR TITLE
fix: default arguments with non-PyAny `IntoPyObject::Target`

### DIFF
--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -30,6 +30,9 @@ def create_a(x:int=2) -> A:
 def create_dict(n:int) -> dict[int, list[int]]:
     ...
 
+def default_value(num:Number=...) -> Number:
+    ...
+
 def echo_path(path:str | os.PathLike | pathlib.Path) -> str:
     ...
 

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -102,6 +102,14 @@ pub enum Number {
 
 module_variable!("pure", "MY_CONSTANT", usize);
 
+// Test if non-any PyObject Target can be a default value
+#[gen_stub_pyfunction]
+#[pyfunction]
+#[pyo3(signature = (num = Number::Float))]
+fn default_value(num: Number) -> Number {
+    num
+}
+
 /// Initializes the Python module
 #[pymodule]
 fn pure(m: &Bound<PyModule>) -> PyResult<()> {
@@ -116,6 +124,7 @@ fn pure(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(str_len, m)?)?;
     m.add_function(wrap_pyfunction!(echo_path, m)?)?;
     m.add_function(wrap_pyfunction!(ahash_dict, m)?)?;
+    m.add_function(wrap_pyfunction!(default_value, m)?)?;
     Ok(())
 }
 

--- a/pyo3-stub-gen-derive/src/gen_stub/signature.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/signature.rs
@@ -105,7 +105,7 @@ impl ToTokens for ArgsWithSignature<'_> {
                                         ::pyo3::prepare_freethreaded_python();
                                         ::pyo3::Python::with_gil(|py| -> String {
                                             let v: #ty = #value;
-                                            if let Ok(py_obj) = <#ty as ::pyo3::IntoPyObject>::into_pyobject(v, py) {
+                                            if let Ok(py_obj) = <#ty as ::pyo3::IntoPyObjectExt>::into_bound_py_any(v, py) {
                                                 ::pyo3_stub_gen::util::fmt_py_obj(&py_obj)
                                             } else {
                                                 "...".to_owned()

--- a/pyo3-stub-gen/src/util.rs
+++ b/pyo3-stub-gen/src/util.rs
@@ -35,7 +35,7 @@ pub fn all_builtin_types(any: &Bound<'_, PyAny>) -> bool {
 
 pub fn fmt_py_obj(any: &Bound<'_, PyAny>) -> String {
     if all_builtin_types(any) {
-        if let Ok(py_str) = any.as_any().repr() {
+        if let Ok(py_str) = any.repr() {
             return py_str.to_string();
         }
     }

--- a/pyo3-stub-gen/src/util.rs
+++ b/pyo3-stub-gen/src/util.rs
@@ -1,6 +1,7 @@
 use pyo3::{prelude::*, types::*};
 
-pub fn all_builtin_types(any: &Bound<'_, PyAny>) -> bool {
+pub fn all_builtin_types<T>(input: &Bound<'_, T>) -> bool {
+    let any = input.as_any();
     if any.is_instance_of::<PyString>()
         || any.is_instance_of::<PyBool>()
         || any.is_instance_of::<PyInt>()
@@ -33,9 +34,10 @@ pub fn all_builtin_types(any: &Bound<'_, PyAny>) -> bool {
     false
 }
 
-pub fn fmt_py_obj(any: &Bound<'_, PyAny>) -> String {
+pub fn fmt_py_obj<T>(input: &Bound<'_, T>) -> String {
+    let any = input.as_any();
     if all_builtin_types(any) {
-        if let Ok(py_str) = any.repr() {
+        if let Ok(py_str) = any.as_any().repr() {
             return py_str.to_string();
         }
     }

--- a/pyo3-stub-gen/src/util.rs
+++ b/pyo3-stub-gen/src/util.rs
@@ -1,7 +1,6 @@
 use pyo3::{prelude::*, types::*};
 
-pub fn all_builtin_types<T>(input: &Bound<'_, T>) -> bool {
-    let any = input.as_any();
+pub fn all_builtin_types(any: &Bound<'_, PyAny>) -> bool {
     if any.is_instance_of::<PyString>()
         || any.is_instance_of::<PyBool>()
         || any.is_instance_of::<PyInt>()
@@ -34,8 +33,7 @@ pub fn all_builtin_types<T>(input: &Bound<'_, T>) -> bool {
     false
 }
 
-pub fn fmt_py_obj<T>(input: &Bound<'_, T>) -> String {
-    let any = input.as_any();
+pub fn fmt_py_obj(any: &Bound<'_, PyAny>) -> String {
     if all_builtin_types(any) {
         if let Ok(py_str) = any.as_any().repr() {
             return py_str.to_string();


### PR DESCRIPTION
#135 introduces optional argument rendering for primitive types. This accidentally rejects default argument with non-`PyAny` `IntoPyObject::Target`. This PR fixes it.
