### PR TITLE
Support PyStubType for numpy's PyReadonlyArray

### DIFF
--- a/pyo3-stub-gen/src/stub_type/numpy.rs
+++ b/pyo3-stub-gen/src/stub_type/numpy.rs
@@ -1,6 +1,6 @@
 use super::{PyStubType, TypeInfo};
 use maplit::hashset;
-use numpy::{PyArray, PyUntypedArray};
+use numpy::{ndarray::Dimension, Element, PyArray, PyReadonlyArray, PyUntypedArray};
 
 trait NumPyScalar {
     fn type_() -> TypeInfo;
@@ -48,6 +48,21 @@ impl PyStubType for PyUntypedArray {
         TypeInfo {
             name: "numpy.typing.NDArray[typing.Any]".into(),
             import: hashset!["numpy.typing".into(), "typing".into()],
+        }
+    }
+}
+
+impl<'py, T, D> PyStubType for PyReadonlyArray<'py, T, D>
+where
+    T: NumPyScalar + Element,
+    D: Dimension,
+{
+    fn type_output() -> TypeInfo {
+        let TypeInfo { name, mut import } = T::type_();
+        import.insert("numpy.typing".into());
+        TypeInfo {
+            name: format!("numpy.typing.NDArray[{name}]"),
+            import,
         }
     }
 }

--- a/pyo3-stub-gen/src/stub_type/numpy.rs
+++ b/pyo3-stub-gen/src/stub_type/numpy.rs
@@ -1,6 +1,8 @@
 use super::{PyStubType, TypeInfo};
 use maplit::hashset;
-use numpy::{ndarray::Dimension, Element, PyArray, PyReadonlyArray, PyUntypedArray};
+use numpy::{
+    ndarray::Dimension, Element, PyArray, PyReadonlyArray, PyReadwriteArray, PyUntypedArray,
+};
 
 trait NumPyScalar {
     fn type_() -> TypeInfo;
@@ -52,17 +54,22 @@ impl PyStubType for PyUntypedArray {
     }
 }
 
-impl<'py, T, D> PyStubType for PyReadonlyArray<'py, T, D>
+impl<T, D> PyStubType for PyReadonlyArray<'_, T, D>
 where
     T: NumPyScalar + Element,
     D: Dimension,
 {
     fn type_output() -> TypeInfo {
-        let TypeInfo { name, mut import } = T::type_();
-        import.insert("numpy.typing".into());
-        TypeInfo {
-            name: format!("numpy.typing.NDArray[{name}]"),
-            import,
-        }
+        PyArray::<T, D>::type_output()
+    }
+}
+
+impl<T, D> PyStubType for PyReadwriteArray<'_, T, D>
+where
+    T: NumPyScalar + Element,
+    D: Dimension,
+{
+    fn type_output() -> TypeInfo {
+        PyArray::<T, D>::type_output()
     }
 }


### PR DESCRIPTION
The PyStubType for the `PyReadonlyArray was not support, I add it to the numpy.rs and it seems works for my case where the type is PyReadonlyArray.