### PR TITLE
new should have doc comment

### DIFF
--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -10,7 +10,9 @@ from enum import Enum, auto
 MY_CONSTANT: builtins.int
 class A:
     x: builtins.int
-    def __new__(cls,x:builtins.int): ...
+    def __new__(cls,x:builtins.int):
+        ...
+
     def show_x(self) -> None:
         ...
 

--- a/pyo3-stub-gen-derive/src/gen_stub/new.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/new.rs
@@ -1,3 +1,5 @@
+use crate::gen_stub::extract_documents;
+
 use super::{parse_args, parse_pyo3_attrs, ArgInfo, ArgsWithSignature, Attr, Signature};
 
 use proc_macro2::TokenStream as TokenStream2;
@@ -8,6 +10,7 @@ use syn::{Error, ImplItemFn, Result};
 pub struct NewInfo {
     args: Vec<ArgInfo>,
     sig: Option<Signature>,
+    doc: String,
 }
 
 impl NewInfo {
@@ -22,6 +25,7 @@ impl TryFrom<ImplItemFn> for NewInfo {
     fn try_from(item: ImplItemFn) -> Result<Self> {
         assert!(Self::is_candidate(&item)?);
         let ImplItemFn { attrs, sig, .. } = item;
+        let doc = extract_documents(&attrs).join("\n");
         let attrs = parse_pyo3_attrs(&attrs)?;
         let mut new_sig = None;
         for attr in attrs {
@@ -32,17 +36,19 @@ impl TryFrom<ImplItemFn> for NewInfo {
         Ok(NewInfo {
             args: parse_args(sig.inputs)?,
             sig: new_sig,
+            doc,
         })
     }
 }
 
 impl ToTokens for NewInfo {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
-        let Self { args, sig } = self;
+        let Self { args, sig, doc } = self;
         let args_with_sig = ArgsWithSignature { args, sig };
         tokens.append_all(quote! {
             ::pyo3_stub_gen::type_info::NewInfo {
                 args: #args_with_sig,
+                doc: #doc,
             }
         })
     }

--- a/pyo3-stub-gen/src/generate/method.rs
+++ b/pyo3-stub-gen/src/generate/method.rs
@@ -59,16 +59,27 @@ impl fmt::Display for MethodDef {
         }
         writeln!(f, ") -> {}:", self.r#return)?;
 
-        let doc = self.doc;
+        write!(f, "{}", DocPrinter(self.doc))?;
+        writeln!(f, "{indent}{indent}...")?;
+        writeln!(f)?;
+        Ok(())
+    }
+}
+
+pub struct DocPrinter(pub &'static str);
+
+impl fmt::Display for DocPrinter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let doc = self.0;
         if !doc.is_empty() {
+            let indent = indent();
             writeln!(f, r#"{indent}{indent}r""""#)?;
             for line in doc.lines() {
                 writeln!(f, "{indent}{indent}{}", line)?;
             }
             writeln!(f, r#"{indent}{indent}""""#)?;
         }
-        writeln!(f, "{indent}{indent}...")?;
-        writeln!(f)?;
+
         Ok(())
     }
 }

--- a/pyo3-stub-gen/src/generate/new.rs
+++ b/pyo3-stub-gen/src/generate/new.rs
@@ -5,6 +5,7 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq)]
 pub struct NewDef {
     pub args: Vec<Arg>,
+    pub doc: &'static str,
 }
 
 impl Import for NewDef {
@@ -21,6 +22,7 @@ impl From<&NewInfo> for NewDef {
     fn from(info: &NewInfo) -> Self {
         Self {
             args: info.args.iter().map(Arg::from).collect(),
+            doc: info.doc,
         }
     }
 }
@@ -35,7 +37,11 @@ impl fmt::Display for NewDef {
                 write!(f, ", ")?;
             }
         }
-        writeln!(f, "): ...")?;
+        writeln!(f, "):")?;
+        write!(f, "{}", DocPrinter(self.doc))?;
+        writeln!(f, "{indent}{indent}...")?;
+        writeln!(f)?;
+
         Ok(())
     }
 }

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -88,6 +88,8 @@ pub struct MemberInfo {
 #[derive(Debug)]
 pub struct NewInfo {
     pub args: &'static [ArgInfo],
+    /// Docstring
+    pub doc: &'static str,
 }
 
 /// Info of `#[pymethod]`


### PR DESCRIPTION
Currently __new__ methods are missing documentation. This PR transports the rust function comment and prints it into the generated pyi files.