### PR TITLE
Do not upgrade pyo3 and numpy automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
+    # Ignore specific dependencies
+    ignore:
+      - dependency-name: "pyo3"
+      - dependency-name: "numpy"
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to manage dependency updates more effectively. The most important change is the addition of specific dependencies to the ignore list.

Dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R25-R28): Added `pyo3` and `numpy` to the ignore list to prevent Dependabot from updating these dependencies.