### PR TITLE
feat(builtins): Add `Ipv4Addr` and `Ipv6Addr` PyStubType impl

### DIFF
--- a/pyo3-stub-gen/src/stub_type/builtins.rs
+++ b/pyo3-stub-gen/src/stub_type/builtins.rs
@@ -4,6 +4,7 @@ use crate::stub_type::*;
 use std::{
     borrow::Cow,
     ffi::{OsStr, OsString},
+    net::{Ipv4Addr, Ipv6Addr},
     path::PathBuf,
     rc::Rc,
     sync::Arc,
@@ -90,6 +91,9 @@ impl_with_module!(FixedOffset, "datetime.tzinfo", "datetime");
 impl_with_module!(Utc, "datetime.tzinfo", "datetime");
 impl_with_module!(std::time::Duration, "datetime.timedelta", "datetime");
 impl_with_module!(chrono::Duration, "datetime.timedelta", "datetime");
+
+impl_with_module!(Ipv4Addr, "ipaddress.IPv4Address", "ipaddress");
+impl_with_module!(Ipv6Addr, "ipaddress.IPv6Address", "ipaddress");
 
 impl<T: PyStubType> PyStubType for &T {
     fn type_input() -> TypeInfo {


### PR DESCRIPTION
This pull request adds support for representing IP addresses in the `pyo3-stub-gen` library by introducing mappings for `Ipv4Addr` and `Ipv6Addr`. The changes include importing the necessary modules and defining the appropriate type mappings.

### Enhancements to IP address support:

* [`pyo3-stub-gen/src/stub_type/builtins.rs`](diffhunk://#diff-1d44fb54fbb6ce20fbb2afb21d6d97dfb1f1559ab4e876a01a0c8fbcdf39681aR7): Added `Ipv4Addr` and `Ipv6Addr` to the list of imported modules to enable their usage in the library.
* [`pyo3-stub-gen/src/stub_type/builtins.rs`](diffhunk://#diff-1d44fb54fbb6ce20fbb2afb21d6d97dfb1f1559ab4e876a01a0c8fbcdf39681aR95-R97): Introduced type mappings for `Ipv4Addr` and `Ipv6Addr` to `ipaddress.IPv4Address` and `ipaddress.IPv6Address` respectively, ensuring compatibility with Python's `ipaddress` module.