### PR TITLE
bugfix for issue #174

### DIFF
--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -6,7 +6,7 @@ import datetime
 import os
 import pathlib
 import typing
-from enum import Enum, auto
+from enum import Enum
 
 MY_CONSTANT: builtins.int
 class A:
@@ -25,8 +25,8 @@ class MyDate(datetime.date):
     ...
 
 class Number(Enum):
-    FLOAT = auto()
-    INTEGER = auto()
+    FLOAT = ...
+    INTEGER = ...
 
     is_float: builtins.bool
     r"""
@@ -39,8 +39,8 @@ class Number(Enum):
     """
 
 class NumberRenameAll(Enum):
-    FLOAT = auto()
-    INTEGER = auto()
+    FLOAT = ...
+    INTEGER = ...
 
 def ahash_dict() -> builtins.dict[builtins.str, builtins.int]: ...
 

--- a/pyo3-stub-gen/src/generate/enum_.rs
+++ b/pyo3-stub-gen/src/generate/enum_.rs
@@ -29,7 +29,7 @@ impl fmt::Display for EnumDef {
         let indent = indent();
         docstring::write_docstring(f, self.doc, indent)?;
         for variants in self.variants {
-            writeln!(f, "{indent}{} = auto()", variants)?;
+            writeln!(f, "{indent}{} = ...", variants)?;
         }
         for member in &self.members {
             writeln!(f)?;

--- a/pyo3-stub-gen/src/generate/module.rs
+++ b/pyo3-stub-gen/src/generate/module.rs
@@ -48,7 +48,7 @@ impl fmt::Display for Module {
             writeln!(f, "from . import {}", submod)?;
         }
         if !self.enum_.is_empty() {
-            writeln!(f, "from enum import Enum, auto")?;
+            writeln!(f, "from enum import Enum")?;
         }
         writeln!(f)?;
 


### PR DESCRIPTION
"auto()" suggests int enums, but pyo3 does not offer them, therefore use "..." instead

this fixed issue #174, if you agree with the statement written there, please merge my change.