### PR TITLE
Implement `PyStubType` for `either::Either`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "either",
  "indexmap",
  "inventory",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [workspace.dependencies]
+either = "1.15.0"
 ahash = "0.8.11"
 anyhow = "1.0.98"
 chrono = "0.4.40"

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -18,6 +18,7 @@ log.workspace = true
 maplit.workspace = true
 num-complex.workspace = true
 numpy = { workspace = true, optional = true }
+either = { workspace = true, optional = true }
 pyo3.workspace = true
 serde.workspace = true
 toml.workspace = true
@@ -30,5 +31,6 @@ path = "../pyo3-stub-gen-derive"
 test-case.workspace = true
 
 [features]
-default = ["numpy"]
+default = ["numpy", "either"]
 numpy = ["dep:numpy"]
+either = ["dep:either"]

--- a/pyo3-stub-gen/src/stub_type.rs
+++ b/pyo3-stub-gen/src/stub_type.rs
@@ -5,6 +5,9 @@ mod pyo3;
 #[cfg(feature = "numpy")]
 mod numpy;
 
+#[cfg(feature = "either")]
+mod either;
+
 use maplit::hashset;
 use std::{collections::HashSet, fmt, ops};
 

--- a/pyo3-stub-gen/src/stub_type/either.rs
+++ b/pyo3-stub-gen/src/stub_type/either.rs
@@ -1,0 +1,46 @@
+use std::collections::HashSet;
+
+use super::{ModuleRef, PyStubType, TypeInfo};
+
+impl<L: PyStubType, R: PyStubType> PyStubType for either::Either<L, R> {
+    fn type_input() -> TypeInfo {
+        let TypeInfo {
+            name: name_l,
+            import: import_l,
+        } = L::type_input();
+        let TypeInfo {
+            name: name_r,
+            import: import_r,
+        } = R::type_input();
+
+        let mut import: HashSet<ModuleRef> =
+            import_l.into_iter().chain(import_r.into_iter()).collect();
+
+        import.insert("typing".into());
+
+        TypeInfo {
+            name: format!("typing.Union[{name_l}, {name_r}]"),
+            import,
+        }
+    }
+    fn type_output() -> TypeInfo {
+        let TypeInfo {
+            name: name_l,
+            import: import_l,
+        } = L::type_output();
+        let TypeInfo {
+            name: name_r,
+            import: import_r,
+        } = R::type_output();
+
+        let mut import: HashSet<ModuleRef> =
+            import_l.into_iter().chain(import_r.into_iter()).collect();
+
+        import.insert("typing".into());
+
+        TypeInfo {
+            name: format!("typing.Union[{name_l}, {name_r}]"),
+            import,
+        }
+    }
+}


### PR DESCRIPTION
Adding stubs for [pyo3 support for `either::Either`](https://docs.rs/pyo3/latest/pyo3/either/index.html).