### PR TITLE
Derive classes for rich enums

### DIFF
--- a/pyo3-stub-gen-derive/src/gen_stub.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub.rs
@@ -29,6 +29,7 @@
 //!             },
 //!         ],
 //!         doc: "",
+//!         classes: &[],
 //!         bases: &[],
 //!     }
 //! }
@@ -75,6 +76,7 @@ mod renaming;
 mod signature;
 mod stub_type;
 mod util;
+mod variant;
 
 use arg::*;
 use attr::*;
@@ -107,6 +109,19 @@ pub fn pyclass(item: TokenStream2) -> Result<TokenStream2> {
 
 pub fn pyclass_enum(item: TokenStream2) -> Result<TokenStream2> {
     let inner = PyEnumInfo::try_from(parse2::<ItemEnum>(item.clone())?)?;
+    let derive_stub_type = StubType::from(&inner);
+    Ok(quote! {
+        #item
+        #derive_stub_type
+        pyo3_stub_gen::inventory::submit! {
+            #inner
+        }
+    })
+}
+
+
+pub fn pyclass_complex_enum(item: TokenStream2) -> Result<TokenStream2> {
+    let inner = PyClassInfo::try_from(parse2::<ItemEnum>(item.clone())?)?;
     let derive_stub_type = StubType::from(&inner);
     Ok(quote! {
         #item

--- a/pyo3-stub-gen-derive/src/gen_stub.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub.rs
@@ -29,7 +29,6 @@
 //!             },
 //!         ],
 //!         doc: "",
-//!         classes: &[],
 //!         bases: &[],
 //!     }
 //! }
@@ -69,7 +68,9 @@ mod attr;
 mod member;
 mod method;
 mod pyclass;
+mod pyclass_tree;
 mod pyclass_enum;
+mod pyclass_rich_enum;
 mod pyfunction;
 mod pymethods;
 mod renaming;
@@ -84,6 +85,7 @@ use member::*;
 use method::*;
 use pyclass::*;
 use pyclass_enum::*;
+use pyclass_rich_enum::*;
 use pyfunction::*;
 use pymethods::*;
 use renaming::*;
@@ -120,8 +122,8 @@ pub fn pyclass_enum(item: TokenStream2) -> Result<TokenStream2> {
 }
 
 
-pub fn pyclass_complex_enum(item: TokenStream2) -> Result<TokenStream2> {
-    let inner = PyClassInfo::try_from(parse2::<ItemEnum>(item.clone())?)?;
+pub fn pyclass_rich_enum(item: TokenStream2) -> Result<TokenStream2> {
+    let inner = PyRichEnumInfo::try_from(parse2::<ItemEnum>(item.clone())?)?;
     let derive_stub_type = StubType::from(&inner);
     Ok(quote! {
         #item

--- a/pyo3-stub-gen-derive/src/gen_stub/member.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/member.rs
@@ -93,8 +93,10 @@ impl MemberInfo {
         let doc = extract_documents(&attrs).join("\n");
 
         if let Fields::Unnamed(fields) = fields {
-
-            let types: Type = parse_quote!{ #fields };
+            
+            let punctuated = fields.unnamed;
+            
+            let types: Type = parse_quote!{ ( #punctuated , ) };
             Ok(Self {
                 name: field_name,
                 r#type: types,

--- a/pyo3-stub-gen-derive/src/gen_stub/member.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/member.rs
@@ -2,9 +2,11 @@ use crate::gen_stub::extract_documents;
 
 use super::{escape_return_type, parse_pyo3_attrs, Attr};
 
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::{Error, Field, ImplItemFn, Result, Type};
+use syn::{parse_quote, Error, Field, Fields, ImplItemFn, Result, Type, Variant};
+use syn::spanned::Spanned;
+use crate::gen_stub::renaming::RenamingRule;
 
 #[derive(Debug)]
 pub struct MemberInfo {
@@ -65,6 +67,42 @@ impl TryFrom<Field> for MemberInfo {
             r#type: ty,
             doc,
         })
+    }
+}
+
+impl MemberInfo {
+    pub fn from_variant(variant: Variant, _enum: Ident, renaming_rule: &Option<RenamingRule>) -> Result<Self> {
+        let span = variant.span();
+        let Variant {
+            ident,
+            fields,
+            attrs,
+            ..
+        } = variant.clone();
+
+        let mut field_name = None;
+        for attr in parse_pyo3_attrs(&attrs)? {
+            if let Attr::Name(name) = attr {
+                field_name = Some(name);
+            }
+        }
+        let mut field_name = field_name.unwrap_or(ident.to_string());
+        if let Some(renaming_rule) = renaming_rule {
+            field_name = renaming_rule.apply(&field_name);
+        }
+        let doc = extract_documents(&attrs).join("\n");
+
+        if let Fields::Unnamed(fields) = fields {
+
+            let types: Type = parse_quote!{ #fields };
+            Ok(Self {
+                name: field_name,
+                r#type: types,
+                doc,
+            })
+        } else {
+            Err(Error::new(span, "Variant must be unnamed"))
+        }
     }
 }
 

--- a/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
@@ -1,7 +1,9 @@
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::{parse_quote, Error, ItemStruct, Result, Type};
-
+use syn::{parse_quote, Error, Fields, ItemEnum, ItemStruct, Result, Type, Variant};
+use syn::spanned::Spanned;
+use crate::gen_stub::renaming::RenamingRule;
+use crate::gen_stub::variant::VariantInfo;
 use super::{extract_documents, parse_pyo3_attrs, util::quote_option, Attr, MemberInfo, StubType};
 
 pub struct PyClassInfo {
@@ -9,6 +11,7 @@ pub struct PyClassInfo {
     struct_type: Type,
     module: Option<String>,
     members: Vec<MemberInfo>,
+    classes: Vec<PyClassInfo>,
     doc: String,
     bases: Vec<Type>,
 }
@@ -69,6 +72,116 @@ impl TryFrom<ItemStruct> for PyClassInfo {
             module,
             doc,
             bases,
+            classes: Vec::new(),
+        })
+    }
+}
+
+impl PyClassInfo {
+    pub fn from_variant(variant: Variant, enum_: Ident, renaming_rule: &Option<RenamingRule>) -> Result<Self> {
+        let Variant {
+            ident,
+            fields,
+            attrs,
+            ..
+        } = variant;
+
+        let struct_type: Type = parse_quote!(#enum_);
+        let mut pyclass_name = None;
+        let mut module = None;
+        let mut bases = Vec::new();
+        for attr in parse_pyo3_attrs(&attrs)? {
+            match attr {
+                Attr::Name(name) => pyclass_name = Some(name),
+                Attr::Module(name) => {
+                    module = Some(name);
+                }
+                Attr::Extends(typ) => bases.push(typ),
+                _ => {}
+            }
+        }
+
+        let mut pyclass_name = pyclass_name.unwrap_or_else(|| ident.to_string());
+        if let Some(renaming_rule) = renaming_rule {
+            pyclass_name = renaming_rule.apply(&pyclass_name);
+        }
+
+        let mut members = Vec::new();
+
+        match fields {
+            Fields::Unit => {},
+            Fields::Named(fields) => {
+                for field in fields.named {
+                    members.push(MemberInfo::try_from(field)?)
+                }
+            },
+            Fields::Unnamed(_) => {
+                return Err(Error::new(fields.span(), "Unnamed fields are not supported for PyClassInfo"))
+            }
+        }
+
+
+        let doc = extract_documents(&attrs).join("\n");
+        Ok(Self {
+            struct_type,
+            pyclass_name,
+            members,
+            module,
+            doc,
+            bases,
+            classes: Vec::new(),
+        })
+    }
+}
+
+impl TryFrom<ItemEnum> for PyClassInfo {
+    type Error = Error;
+
+    fn try_from(item: ItemEnum) -> Result<Self> {
+        let ItemEnum {
+            variants,
+            attrs,
+            ident,
+
+            ..
+        } = item;
+
+        let doc = extract_documents(&attrs).join("\n");
+        let mut pyclass_name = None;
+        let mut module = None;
+        let mut renaming_rule = None;
+        for attr in parse_pyo3_attrs(&attrs)? {
+            match attr {
+                Attr::Name(name) => pyclass_name = Some(name),
+                Attr::Module(name) => module = Some(name),
+                Attr::RenameAll(name) => renaming_rule = Some(name),
+                _ => {}
+            }
+        }
+
+        let struct_type = parse_quote!(#ident);
+        let pyclass_name = pyclass_name.unwrap_or_else(|| ident.clone().to_string());
+
+        let mut members = Vec::new();
+        let mut classes = Vec::new();
+        for variant in variants {
+            let variant = VariantInfo::from_variant(variant, ident.clone(), &renaming_rule)?;
+            match variant {
+                VariantInfo::Tuple {tuple} => members.push(tuple),
+                VariantInfo::Struct {pyclass} => {
+                    classes.push(pyclass)
+                },
+            }
+        }
+
+        Ok(Self {
+            doc,
+            struct_type,
+            pyclass_name,
+            module,
+            members,
+            classes,
+            bases: Vec::new(),
         })
     }
 }
@@ -82,6 +195,7 @@ impl ToTokens for PyClassInfo {
             doc,
             module,
             bases,
+            classes,
         } = self;
         let module = quote_option(module);
         tokens.append_all(quote! {
@@ -91,6 +205,7 @@ impl ToTokens for PyClassInfo {
                 members: &[ #( #members),* ],
                 module: #module,
                 doc: #doc,
+                classes: &[ #( #classes ),* ],
                 bases: &[ #( <#bases as ::pyo3_stub_gen::PyStubType>::type_output ),* ],
             }
         })
@@ -145,9 +260,71 @@ mod test {
             ],
             module: Some("my_module"),
             doc: "",
+            classes: &[],
             bases: &[],
         }
         "###);
+        Ok(())
+    }
+
+    #[test]
+    fn test_complex_enum() -> Result<()> {
+        let input: ItemEnum = parse_str(
+            r#"
+            #[pyclass(mapping, module = "my_module", name = "Placeholder")]
+            #[derive(
+                Debug, Clone, PyNeg, PyAdd, PySub, PyMul, PyDiv, PyMod, PyPow, PyCmp, PyIndex, PyPrint,
+            )]
+            pub enum PyPlaceholder {
+                name(String),
+                ndim{count: usize},
+                description,
+            }
+            "#,
+        )?;
+        let out = PyClassInfo::try_from(input)?.to_token_stream();
+        insta::assert_snapshot!(format_as_value(out), @r#"
+        ::pyo3_stub_gen::type_info::PyClassInfo {
+            pyclass_name: "Placeholder",
+            struct_id: std::any::TypeId::of::<PyPlaceholder>,
+            members: &[
+                ::pyo3_stub_gen::type_info::MemberInfo {
+                    name: "name",
+                    r#type: <(String) as ::pyo3_stub_gen::PyStubType>::type_output,
+                    doc: "",
+                },
+            ],
+            module: Some("my_module"),
+            doc: "",
+            classes: &[
+                ::pyo3_stub_gen::type_info::PyClassInfo {
+                    pyclass_name: "ndim",
+                    struct_id: std::any::TypeId::of::<PyPlaceholder>,
+                    members: &[
+                        ::pyo3_stub_gen::type_info::MemberInfo {
+                            name: "count",
+                            r#type: <usize as ::pyo3_stub_gen::PyStubType>::type_output,
+                            doc: "",
+                        },
+                    ],
+                    module: None,
+                    doc: "",
+                    classes: &[],
+                    bases: &[],
+                },
+                ::pyo3_stub_gen::type_info::PyClassInfo {
+                    pyclass_name: "description",
+                    struct_id: std::any::TypeId::of::<PyPlaceholder>,
+                    members: &[],
+                    module: None,
+                    doc: "",
+                    classes: &[],
+                    bases: &[],
+                },
+            ],
+            bases: &[],
+        }
+        "#);
         Ok(())
     }
 

--- a/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
@@ -1,9 +1,6 @@
-use proc_macro2::{Ident, TokenStream as TokenStream2};
+use proc_macro2::{TokenStream as TokenStream2};
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::{parse_quote, Error, Fields, ItemEnum, ItemStruct, Result, Type, Variant};
-use syn::spanned::Spanned;
-use crate::gen_stub::renaming::RenamingRule;
-use crate::gen_stub::variant::VariantInfo;
+use syn::{parse_quote, Error, ItemStruct, Result, Type};
 use super::{extract_documents, parse_pyo3_attrs, util::quote_option, Attr, MemberInfo, StubType};
 
 pub struct PyClassInfo {
@@ -11,7 +8,6 @@ pub struct PyClassInfo {
     struct_type: Type,
     module: Option<String>,
     members: Vec<MemberInfo>,
-    classes: Vec<PyClassInfo>,
     doc: String,
     bases: Vec<Type>,
 }
@@ -72,116 +68,6 @@ impl TryFrom<ItemStruct> for PyClassInfo {
             module,
             doc,
             bases,
-            classes: Vec::new(),
-        })
-    }
-}
-
-impl PyClassInfo {
-    pub fn from_variant(variant: Variant, enum_: Ident, renaming_rule: &Option<RenamingRule>) -> Result<Self> {
-        let Variant {
-            ident,
-            fields,
-            attrs,
-            ..
-        } = variant;
-
-        let struct_type: Type = parse_quote!(#enum_);
-        let mut pyclass_name = None;
-        let mut module = None;
-        let mut bases = Vec::new();
-        for attr in parse_pyo3_attrs(&attrs)? {
-            match attr {
-                Attr::Name(name) => pyclass_name = Some(name),
-                Attr::Module(name) => {
-                    module = Some(name);
-                }
-                Attr::Extends(typ) => bases.push(typ),
-                _ => {}
-            }
-        }
-
-        let mut pyclass_name = pyclass_name.unwrap_or_else(|| ident.to_string());
-        if let Some(renaming_rule) = renaming_rule {
-            pyclass_name = renaming_rule.apply(&pyclass_name);
-        }
-
-        let mut members = Vec::new();
-
-        match fields {
-            Fields::Unit => {},
-            Fields::Named(fields) => {
-                for field in fields.named {
-                    members.push(MemberInfo::try_from(field)?)
-                }
-            },
-            Fields::Unnamed(_) => {
-                return Err(Error::new(fields.span(), "Unnamed fields are not supported for PyClassInfo"))
-            }
-        }
-
-
-        let doc = extract_documents(&attrs).join("\n");
-        Ok(Self {
-            struct_type,
-            pyclass_name,
-            members,
-            module,
-            doc,
-            bases,
-            classes: Vec::new(),
-        })
-    }
-}
-
-impl TryFrom<ItemEnum> for PyClassInfo {
-    type Error = Error;
-
-    fn try_from(item: ItemEnum) -> Result<Self> {
-        let ItemEnum {
-            variants,
-            attrs,
-            ident,
-
-            ..
-        } = item;
-
-        let doc = extract_documents(&attrs).join("\n");
-        let mut pyclass_name = None;
-        let mut module = None;
-        let mut renaming_rule = None;
-        for attr in parse_pyo3_attrs(&attrs)? {
-            match attr {
-                Attr::Name(name) => pyclass_name = Some(name),
-                Attr::Module(name) => module = Some(name),
-                Attr::RenameAll(name) => renaming_rule = Some(name),
-                _ => {}
-            }
-        }
-
-        let struct_type = parse_quote!(#ident);
-        let pyclass_name = pyclass_name.unwrap_or_else(|| ident.clone().to_string());
-
-        let mut members = Vec::new();
-        let mut classes = Vec::new();
-        for variant in variants {
-            let variant = VariantInfo::from_variant(variant, ident.clone(), &renaming_rule)?;
-            match variant {
-                VariantInfo::Tuple {tuple} => members.push(tuple),
-                VariantInfo::Struct {pyclass} => {
-                    classes.push(pyclass)
-                },
-            }
-        }
-
-        Ok(Self {
-            doc,
-            struct_type,
-            pyclass_name,
-            module,
-            members,
-            classes,
-            bases: Vec::new(),
         })
     }
 }
@@ -195,7 +81,6 @@ impl ToTokens for PyClassInfo {
             doc,
             module,
             bases,
-            classes,
         } = self;
         let module = quote_option(module);
         tokens.append_all(quote! {
@@ -205,7 +90,6 @@ impl ToTokens for PyClassInfo {
                 members: &[ #( #members),* ],
                 module: #module,
                 doc: #doc,
-                classes: &[ #( #classes ),* ],
                 bases: &[ #( <#bases as ::pyo3_stub_gen::PyStubType>::type_output ),* ],
             }
         })
@@ -237,7 +121,7 @@ mod test {
             "#,
         )?;
         let out = PyClassInfo::try_from(input)?.to_token_stream();
-        insta::assert_snapshot!(format_as_value(out), @r###"
+        insta::assert_snapshot!(format_as_value(out), @r#"
         ::pyo3_stub_gen::type_info::PyClassInfo {
             pyclass_name: "Placeholder",
             struct_id: std::any::TypeId::of::<PyPlaceholder>,
@@ -260,68 +144,6 @@ mod test {
             ],
             module: Some("my_module"),
             doc: "",
-            classes: &[],
-            bases: &[],
-        }
-        "###);
-        Ok(())
-    }
-
-    #[test]
-    fn test_complex_enum() -> Result<()> {
-        let input: ItemEnum = parse_str(
-            r#"
-            #[pyclass(mapping, module = "my_module", name = "Placeholder")]
-            #[derive(
-                Debug, Clone, PyNeg, PyAdd, PySub, PyMul, PyDiv, PyMod, PyPow, PyCmp, PyIndex, PyPrint,
-            )]
-            pub enum PyPlaceholder {
-                name(String),
-                ndim{count: usize},
-                description,
-            }
-            "#,
-        )?;
-        let out = PyClassInfo::try_from(input)?.to_token_stream();
-        insta::assert_snapshot!(format_as_value(out), @r#"
-        ::pyo3_stub_gen::type_info::PyClassInfo {
-            pyclass_name: "Placeholder",
-            struct_id: std::any::TypeId::of::<PyPlaceholder>,
-            members: &[
-                ::pyo3_stub_gen::type_info::MemberInfo {
-                    name: "name",
-                    r#type: <(String) as ::pyo3_stub_gen::PyStubType>::type_output,
-                    doc: "",
-                },
-            ],
-            module: Some("my_module"),
-            doc: "",
-            classes: &[
-                ::pyo3_stub_gen::type_info::PyClassInfo {
-                    pyclass_name: "ndim",
-                    struct_id: std::any::TypeId::of::<PyPlaceholder>,
-                    members: &[
-                        ::pyo3_stub_gen::type_info::MemberInfo {
-                            name: "count",
-                            r#type: <usize as ::pyo3_stub_gen::PyStubType>::type_output,
-                            doc: "",
-                        },
-                    ],
-                    module: None,
-                    doc: "",
-                    classes: &[],
-                    bases: &[],
-                },
-                ::pyo3_stub_gen::type_info::PyClassInfo {
-                    pyclass_name: "description",
-                    struct_id: std::any::TypeId::of::<PyPlaceholder>,
-                    members: &[],
-                    module: None,
-                    doc: "",
-                    classes: &[],
-                    bases: &[],
-                },
-            ],
             bases: &[],
         }
         "#);

--- a/pyo3-stub-gen-derive/src/gen_stub/pyclass_rich_enum.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyclass_rich_enum.rs
@@ -1,0 +1,199 @@
+use proc_macro2::{TokenStream as TokenStream2};
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::{parse_quote, Error, ItemEnum, Result, Type};
+use crate::gen_stub::variant::VariantInfo;
+use super::{extract_documents, parse_pyo3_attrs, util::quote_option, Attr, StubType};
+
+pub struct PyRichEnumInfo {
+    pyclass_name: String,
+    struct_type: Type,
+    module: Option<String>,
+    variants: Vec<VariantInfo>,
+    doc: String,
+    bases: Vec<Type>,
+}
+
+impl From<&PyRichEnumInfo> for StubType {
+    fn from(info: &PyRichEnumInfo) -> Self {
+        let PyRichEnumInfo {
+            pyclass_name,
+            module,
+            struct_type,
+            ..
+        } = info;
+        Self {
+            ty: struct_type.clone(),
+            name: pyclass_name.clone(),
+            module: module.clone(),
+        }
+    }
+}
+
+impl TryFrom<ItemEnum> for PyRichEnumInfo {
+    type Error = Error;
+
+    fn try_from(item: ItemEnum) -> Result<Self> {
+        let ItemEnum {
+            variants,
+            attrs,
+            ident,
+
+            ..
+        } = item;
+
+        let doc = extract_documents(&attrs).join("\n");
+        let mut pyclass_name = None;
+        let mut module = None;
+        let mut renaming_rule = None;
+        let mut bases = Vec::new();
+        for attr in parse_pyo3_attrs(&attrs)? {
+            match attr {
+                Attr::Name(name) => pyclass_name = Some(name),
+                Attr::Module(name) => module = Some(name),
+                Attr::RenameAll(name) => renaming_rule = Some(name),
+                Attr::Extends(typ) => bases.push(typ),
+                _ => {}
+            }
+        }
+
+        let struct_type = parse_quote!(#ident);
+        let pyclass_name = pyclass_name.unwrap_or_else(|| ident.clone().to_string());
+
+        let mut items = Vec::new();
+        for variant in variants {
+            items.push(VariantInfo::from_variant(variant, ident.clone(), &renaming_rule)?);
+        }
+
+        Ok(Self {
+            doc,
+            struct_type,
+            pyclass_name,
+            module,
+            bases,
+            variants: items,
+        })
+    }
+}
+
+impl ToTokens for PyRichEnumInfo {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let Self {
+            pyclass_name,
+            struct_type,
+            variants,
+            doc,
+            module,
+            bases,
+            ..
+        } = self;
+        let module = quote_option(module);
+
+        let mut members = Vec::new();
+        let mut classes = Vec::new();
+
+        for variant in variants {
+            match variant {
+                VariantInfo::Struct{pyclass} => classes.push(pyclass),
+                VariantInfo::Tuple{tuple} => members.push(tuple),
+            }
+        }
+
+        tokens.append_all(quote! {
+            ::pyo3_stub_gen::type_info::PyClassTreeInfo {
+                pyclass_name: #pyclass_name,
+                struct_id: std::any::TypeId::of::<#struct_type>,
+                members: &[ #( #members),* ],
+                classes: &[ #( #classes ),* ],
+                bases: &[ #( #bases ),* ],
+                module: #module,
+                doc: #doc,
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use syn::parse_str;
+
+    #[test]
+    fn test_rich_enum() -> Result<()> {
+        let input: ItemEnum = parse_str(
+            r#"
+            #[pyclass(mapping, module = "my_module", name = "Placeholder")]
+            #[derive(
+                Debug, Clone, PyNeg, PyAdd, PySub, PyMul, PyDiv, PyMod, PyPow, PyCmp, PyIndex, PyPrint,
+            )]
+            pub enum PyPlaceholder {
+                #[pyo3(name="Name")]
+                name(String),
+                twonum(i32,f64),
+                ndim{count: usize},
+                description,
+            }
+            "#,
+        )?;
+        let out = PyRichEnumInfo::try_from(input)?.to_token_stream();
+        insta::assert_snapshot!(format_as_value(out), @r#"
+        ::pyo3_stub_gen::type_info::PyClassTreeInfo {
+            pyclass_name: "Placeholder",
+            struct_id: std::any::TypeId::of::<PyPlaceholder>,
+            members: &[
+                ::pyo3_stub_gen::type_info::MemberInfo {
+                    name: "Name",
+                    r#type: <(String,) as ::pyo3_stub_gen::PyStubType>::type_output,
+                    doc: "",
+                },
+                ::pyo3_stub_gen::type_info::MemberInfo {
+                    name: "twonum",
+                    r#type: <(i32, f64) as ::pyo3_stub_gen::PyStubType>::type_output,
+                    doc: "",
+                },
+            ],
+            classes: &[
+                ::pyo3_stub_gen::type_info::PyClassTreeInfo {
+                    pyclass_name: "ndim",
+                    struct_id: std::any::TypeId::of::<PyPlaceholder>,
+                    members: &[
+                        ::pyo3_stub_gen::type_info::MemberInfo {
+                            name: "count",
+                            r#type: <usize as ::pyo3_stub_gen::PyStubType>::type_output,
+                            doc: "",
+                        },
+                    ],
+                    classes: &[],
+                    module: None,
+                    doc: "",
+                    bases: &[],
+                },
+                ::pyo3_stub_gen::type_info::PyClassTreeInfo {
+                    pyclass_name: "description",
+                    struct_id: std::any::TypeId::of::<PyPlaceholder>,
+                    members: &[],
+                    classes: &[],
+                    module: None,
+                    doc: "",
+                    bases: &[],
+                },
+            ],
+            bases: &[],
+            module: Some("my_module"),
+            doc: "",
+        }
+        "#);
+        Ok(())
+    }
+
+    fn format_as_value(tt: TokenStream2) -> String {
+        let ttt = quote! { const _: () = #tt; };
+        let formatted = prettyplease::unparse(&syn::parse_file(&ttt.to_string()).unwrap());
+        formatted
+            .trim()
+            .strip_prefix("const _: () = ")
+            .unwrap()
+            .strip_suffix(';')
+            .unwrap()
+            .to_string()
+    }
+}

--- a/pyo3-stub-gen-derive/src/gen_stub/pyclass_tree.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyclass_tree.rs
@@ -1,0 +1,116 @@
+use proc_macro2::{Ident, TokenStream as TokenStream2};
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::{parse_quote, Error, Fields, Result, Type, Variant};
+use syn::spanned::Spanned;
+use crate::gen_stub::renaming::RenamingRule;
+use super::{extract_documents, parse_pyo3_attrs, util::quote_option, Attr, MemberInfo, StubType};
+
+pub struct PyClassTreeInfo {
+    pyclass_name: String,
+    struct_type: Type,
+    module: Option<String>,
+    members: Vec<MemberInfo>,
+    doc: String,
+    bases: Vec<Type>,
+    classes: Vec<PyClassTreeInfo>
+}
+
+impl From<&PyClassTreeInfo> for StubType {
+    fn from(info: &PyClassTreeInfo) -> Self {
+        let PyClassTreeInfo {
+            pyclass_name,
+            module,
+            struct_type,
+            ..
+        } = info;
+        Self {
+            ty: struct_type.clone(),
+            name: pyclass_name.clone(),
+            module: module.clone(),
+        }
+    }
+}
+
+impl PyClassTreeInfo {
+    pub fn from_variant(variant: Variant, enum_: Ident, renaming_rule: &Option<RenamingRule>) -> Result<Self> {
+        let Variant {
+            ident,
+            fields,
+            attrs,
+            ..
+        } = variant;
+
+        let struct_type: Type = parse_quote!(#enum_);
+        let mut pyclass_name = None;
+        let mut module = None;
+        let mut bases = Vec::new();
+        for attr in parse_pyo3_attrs(&attrs)? {
+            match attr {
+                Attr::Name(name) => pyclass_name = Some(name),
+                Attr::Module(name) => {
+                    module = Some(name);
+                }
+                Attr::Extends(typ) => bases.push(typ),
+                _ => {}
+            }
+        }
+
+        let mut pyclass_name = pyclass_name.unwrap_or_else(|| ident.to_string());
+        if let Some(renaming_rule) = renaming_rule {
+            pyclass_name = renaming_rule.apply(&pyclass_name);
+        }
+
+        let mut members = Vec::new();
+
+        match fields {
+            Fields::Unit => {},
+            Fields::Named(fields) => {
+                for field in fields.named {
+                    members.push(MemberInfo::try_from(field)?)
+                }
+            },
+            Fields::Unnamed(_) => {
+                return Err(Error::new(fields.span(), "Unnamed fields are not supported for PyClassInfo"))
+            }
+        }
+
+
+        let doc = extract_documents(&attrs).join("\n");
+        Ok(Self {
+            struct_type,
+            pyclass_name,
+            members,
+            module,
+            doc,
+            bases,
+            classes: Vec::new(),
+        })
+    }
+}
+
+impl ToTokens for PyClassTreeInfo {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let Self {
+            pyclass_name,
+            struct_type,
+            members,
+            doc,
+            module,
+            bases,
+            classes,
+        } = self;
+        let module = quote_option(module);
+        tokens.append_all(quote! {
+            ::pyo3_stub_gen::type_info::PyClassTreeInfo {
+                pyclass_name: #pyclass_name,
+                struct_id: std::any::TypeId::of::<#struct_type>,
+                members: &[ #( #members),* ],
+                classes: &[ #( #classes ),*],
+                module: #module,
+                doc: #doc,
+                bases: &[ #( <#bases as ::pyo3_stub_gen::PyStubType>::type_output ),* ],
+            }
+        })
+    }
+}
+

--- a/pyo3-stub-gen-derive/src/gen_stub/variant.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/variant.rs
@@ -1,0 +1,57 @@
+use proc_macro2::{Ident, TokenStream as TokenStream2};
+use quote::{ToTokens};
+use syn::{Fields, Result, Variant};
+use crate::gen_stub::member::MemberInfo;
+use crate::gen_stub::pyclass::PyClassInfo;
+use crate::gen_stub::renaming::RenamingRule;
+
+pub enum VariantInfo {
+    Tuple {
+        tuple: MemberInfo
+    },
+    Struct {
+        pyclass: PyClassInfo
+    }
+}
+
+impl From<PyClassInfo> for VariantInfo {
+    fn from(pyclass: PyClassInfo) -> Self {
+        VariantInfo::Struct { pyclass }
+    }
+}
+
+impl From<MemberInfo> for VariantInfo {
+    fn from(member: MemberInfo) -> Self {
+        VariantInfo::Tuple { tuple: member }
+    }
+}
+
+impl VariantInfo {
+    pub fn from_variant(variant: Variant, r#enum: Ident, renaming_rule: &Option<RenamingRule>) -> Result<Self> {
+        match &variant.fields {
+            Fields::Unit |
+            Fields::Named(_) => {
+                Ok(PyClassInfo::from_variant(variant, r#enum, renaming_rule)?.into())
+            }
+            Fields::Unnamed(_) => {
+                Ok(MemberInfo::from_variant(variant, r#enum, renaming_rule)?.into())
+            }
+        }
+
+    }
+}
+
+impl ToTokens for VariantInfo {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        match self {
+            VariantInfo::Tuple { tuple } => {
+                tuple.to_tokens(tokens);
+            }
+            VariantInfo::Struct { pyclass } => {
+                pyclass.to_tokens(tokens);
+            }
+        }
+
+
+    }
+}

--- a/pyo3-stub-gen-derive/src/gen_stub/variant.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/variant.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{ToTokens};
 use syn::{Fields, Result, Variant};
 use crate::gen_stub::member::MemberInfo;
-use crate::gen_stub::pyclass::PyClassInfo;
+use crate::gen_stub::pyclass_tree::PyClassTreeInfo;
 use crate::gen_stub::renaming::RenamingRule;
 
 pub enum VariantInfo {
@@ -10,12 +10,12 @@ pub enum VariantInfo {
         tuple: MemberInfo
     },
     Struct {
-        pyclass: PyClassInfo
+        pyclass: PyClassTreeInfo
     }
 }
 
-impl From<PyClassInfo> for VariantInfo {
-    fn from(pyclass: PyClassInfo) -> Self {
+impl From<PyClassTreeInfo> for VariantInfo {
+    fn from(pyclass: PyClassTreeInfo) -> Self {
         VariantInfo::Struct { pyclass }
     }
 }
@@ -31,7 +31,7 @@ impl VariantInfo {
         match &variant.fields {
             Fields::Unit |
             Fields::Named(_) => {
-                Ok(PyClassInfo::from_variant(variant, r#enum, renaming_rule)?.into())
+                Ok(PyClassTreeInfo::from_variant(variant, r#enum, renaming_rule)?.into())
             }
             Fields::Unnamed(_) => {
                 Ok(MemberInfo::from_variant(variant, r#enum, renaming_rule)?.into())

--- a/pyo3-stub-gen-derive/src/lib.rs
+++ b/pyo3-stub-gen-derive/src/lib.rs
@@ -49,17 +49,19 @@ pub fn gen_stub_pyclass_enum(_attr: TokenStream, item: TokenStream) -> TokenStre
 /// Embed metadata for Python stub file generation for `#[pyclass]` macro with a complex enum
 ///
 /// ```
-/// #[pyo3_stub_gen_derive::gen_stub_pyclass_complex_enum]
+/// #[pyo3_stub_gen_derive::gen_stub_pyclass_rich_enum]
 /// #[pyo3::pyclass(module = "my_module", name = "DataType")]
 /// #[derive(Debug, Clone)]
 /// pub enum PyDataType {
+///     #[pyo3(name = "FLOAT")]
 ///     Float{f: f64},
+///     #[pyo3(name = "INTEGER")]
 ///     Integer(i64),
 /// }
 /// ```
 #[proc_macro_attribute]
-pub fn gen_stub_pyclass_complex_enum(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    gen_stub::pyclass_complex_enum(item.into())
+pub fn gen_stub_pyclass_rich_enum(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    gen_stub::pyclass_rich_enum(item.into())
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }

--- a/pyo3-stub-gen-derive/src/lib.rs
+++ b/pyo3-stub-gen-derive/src/lib.rs
@@ -45,6 +45,25 @@ pub fn gen_stub_pyclass_enum(_attr: TokenStream, item: TokenStream) -> TokenStre
         .into()
 }
 
+
+/// Embed metadata for Python stub file generation for `#[pyclass]` macro with a complex enum
+///
+/// ```
+/// #[pyo3_stub_gen_derive::gen_stub_pyclass_complex_enum]
+/// #[pyo3::pyclass(module = "my_module", name = "DataType")]
+/// #[derive(Debug, Clone)]
+/// pub enum PyDataType {
+///     Float{f: f64},
+///     Integer(i64),
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn gen_stub_pyclass_complex_enum(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    gen_stub::pyclass_complex_enum(item.into())
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
 /// Embed metadata for Python stub file generation for `#[pymethods]` macro
 ///
 /// ```

--- a/pyo3-stub-gen/src/generate/class.rs
+++ b/pyo3-stub-gen/src/generate/class.rs
@@ -24,7 +24,25 @@ impl Import for ClassDef {
         for method in &self.methods {
             import.extend(method.import());
         }
+        for class in &self.classes {
+            import.extend(class.import());
+        }
         import
+    }
+}
+
+impl From<&PyClassTreeInfo> for ClassDef {
+    fn from(info: &PyClassTreeInfo) -> Self {
+        // Since there are multiple `#[pymethods]` for a single class, we need to merge them.
+        // This is only an initializer. See `StubInfo::gather` for the actual merging.
+        Self {
+            name: info.pyclass_name,
+            doc: info.doc,
+            members: info.members.iter().map(MemberDef::from).collect(),
+            methods: Vec::new(),
+            classes: info.classes.iter().map(ClassDef::from).collect(),
+            bases: info.bases.iter().map(|f| f()).collect(),
+        }
     }
 }
 
@@ -37,7 +55,7 @@ impl From<&PyClassInfo> for ClassDef {
             doc: info.doc,
             members: info.members.iter().map(MemberDef::from).collect(),
             methods: Vec::new(),
-            classes: info.classes.iter().map(ClassDef::from).collect(),
+            classes: Vec::new(),
             bases: info.bases.iter().map(|f| f()).collect(),
         }
     }

--- a/pyo3-stub-gen/src/generate/class.rs
+++ b/pyo3-stub-gen/src/generate/class.rs
@@ -9,6 +9,7 @@ pub struct ClassDef {
     pub members: Vec<MemberDef>,
     pub methods: Vec<MethodDef>,
     pub bases: Vec<TypeInfo>,
+    pub classes: Vec<ClassDef>
 }
 
 impl Import for ClassDef {
@@ -36,6 +37,7 @@ impl From<&PyClassInfo> for ClassDef {
             doc: info.doc,
             members: info.members.iter().map(MemberDef::from).collect(),
             methods: Vec::new(),
+            classes: info.classes.iter().map(ClassDef::from).collect(),
             bases: info.bases.iter().map(|f| f()).collect(),
         }
     }
@@ -60,7 +62,13 @@ impl fmt::Display for ClassDef {
         for method in &self.methods {
             method.fmt(f)?;
         }
-        if self.members.is_empty() && self.methods.is_empty() {
+        for class in &self.classes {
+            let emit = format!("{}", class);
+            for line in emit.lines() {
+                writeln!(f, "{}{}", indent, line)?;
+            }
+        }
+        if self.members.is_empty() && self.methods.is_empty() && self.classes.is_empty() {
             writeln!(f, "{indent}...")?;
         }
         writeln!(f)?;

--- a/pyo3-stub-gen/src/generate/stub_info.rs
+++ b/pyo3-stub-gen/src/generate/stub_info.rs
@@ -110,6 +110,12 @@ impl StubInfoBuilder {
             .insert((info.struct_id)(), ClassDef::from(info));
     }
 
+    fn add_class_tree(&mut self, info: &PyClassTreeInfo) {
+        self.get_module(info.module)
+            .class
+            .insert((info.struct_id)(), ClassDef::from(info));
+    }
+
     fn add_enum(&mut self, info: &PyEnumInfo) {
         self.get_module(info.module)
             .enum_
@@ -169,6 +175,9 @@ impl StubInfoBuilder {
     fn build(mut self) -> StubInfo {
         for info in inventory::iter::<PyClassInfo> {
             self.add_class(info);
+        }
+        for info in inventory::iter::<PyClassTreeInfo> {
+            self.add_class_tree(info);
         }
         for info in inventory::iter::<PyEnumInfo> {
             self.add_enum(info);

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -51,6 +51,9 @@
 //!
 //!         doc: "Docstring used in Python",
 //!
+//!         // Used for variants of structured enums
+//!         classes: &[],
+//!
 //!         // Base classes
 //!         bases: &[],
 //!     }

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -51,9 +51,6 @@
 //!
 //!         doc: "Docstring used in Python",
 //!
-//!         // Used for variants of structured enums
-//!         classes: &[],
-//!
 //!         // Base classes
 //!         bases: &[],
 //!     }

--- a/pyo3-stub-gen/src/stub_type/collections.rs
+++ b/pyo3-stub-gen/src/stub_type/collections.rs
@@ -137,7 +137,7 @@ impl<Key: PyStubType, Value: PyStubType, State> PyStubType
 
 macro_rules! impl_tuple {
     ($($T:ident),*) => {
-        impl<$($T: PyStubType),*> PyStubType for ($($T),*) {
+        impl<$($T: PyStubType),*> PyStubType for ($($T),* ,) {
             fn type_output() -> TypeInfo {
                 let mut merged = HashSet::new();
                 let mut names = Vec::new();
@@ -168,6 +168,7 @@ macro_rules! impl_tuple {
     };
 }
 
+impl_tuple!(T1);
 impl_tuple!(T1, T2);
 impl_tuple!(T1, T2, T3);
 impl_tuple!(T1, T2, T3, T4);

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -119,6 +119,7 @@ pub struct PyClassInfo {
     pub doc: &'static str,
     /// static members by `#[pyo3(get, set)]`
     pub members: &'static [MemberInfo],
+    pub classes: &'static [PyClassInfo],
     /// Base classes specified by `#[pyclass(extends = Type)]`
     pub bases: &'static [fn() -> TypeInfo],
 }

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -119,12 +119,45 @@ pub struct PyClassInfo {
     pub doc: &'static str,
     /// static members by `#[pyo3(get, set)]`
     pub members: &'static [MemberInfo],
-    pub classes: &'static [PyClassInfo],
     /// Base classes specified by `#[pyclass(extends = Type)]`
     pub bases: &'static [fn() -> TypeInfo],
 }
 
 inventory::collect!(PyClassInfo);
+
+/// Info of nested `#[pyclass]` with Rust struct and enums
+#[derive(Debug)]
+pub struct PyClassTreeInfo {
+    // Rust struct type-id
+    pub struct_id: fn() -> TypeId,
+    // The name exposed to Python
+    pub pyclass_name: &'static str,
+    /// Module name specified by `#[pyclass(module = "foo.bar")]`
+    pub module: Option<&'static str>,
+    /// Docstring
+    pub doc: &'static str,
+    /// static members by `#[pyo3(get, set)]`
+    pub members: &'static [MemberInfo],
+    pub classes: &'static [PyClassTreeInfo],
+    /// Base classes specified by `#[pyclass(extends = Type)]`
+    pub bases: &'static [fn() -> TypeInfo],
+}
+
+inventory::collect!(PyClassTreeInfo);
+
+// impl From<PyClassInfo> for PyClassTreeInfo {
+//     fn from(info: PyClassInfo) -> Self {
+//         Self {
+//             struct_id: info.struct_id,
+//             pyclass_name: info.pyclass_name,
+//             module: info.module,
+//             doc: info.doc,
+//             members: info.members,
+//             classes: &[],
+//             bases: info.bases,
+//         }
+//     }
+// }
 
 /// Info of `#[pyclass]` with Rust enum
 #[derive(Debug)]


### PR DESCRIPTION
Add new attribute macro `gen_stub_pyclass_rich_enum` that creates internal classes for structured enum variants, and tuples for tuple variants.  

The internal classes reflect in Python how structured variants are exposed by PyO3.   

The tuple type hint may not be the correct way to handle tuple variants.

This change requires a new inventoried struct called `PyClassTreeInfo` that allows for nested classes.

`ClassDef ` now can be created from the import of either PyClassTreeInfo or PyClassInfo and will write indented internal classes to the stub file.

This PR also fixes the implementation on tuples so that tuples of length one are supported.