### PR TITLE
Allow single element tuple as return type (small fix)

### DIFF
--- a/pyo3-stub-gen/src/stub_type/collections.rs
+++ b/pyo3-stub-gen/src/stub_type/collections.rs
@@ -136,15 +136,18 @@ impl<Key: PyStubType, Value: PyStubType, State> PyStubType
 }
 
 macro_rules! impl_tuple {
-    ($($T:ident),*) => {
-        impl<$($T: PyStubType),*> PyStubType for ($($T),*) {
+    (  $T1:ident $(, $T:ident )*) => {
+        impl<$T1: PyStubType $(, $T: PyStubType )*> PyStubType for ($T1 $(, $T )*,) {
             fn type_output() -> TypeInfo {
                 let mut merged = HashSet::new();
                 let mut names = Vec::new();
-                $(
-                let TypeInfo { name, import } = $T::type_output();
+                let TypeInfo { name, import } = $T1::type_output();
                 names.push(name);
                 merged.extend(import);
+                $(
+                    let TypeInfo { name, import } = $T::type_output();
+                    names.push(name);
+                    merged.extend(import);
                 )*
                 TypeInfo {
                     name: format!("tuple[{}]", names.join(", ")),
@@ -154,10 +157,13 @@ macro_rules! impl_tuple {
             fn type_input() -> TypeInfo {
                 let mut merged = HashSet::new();
                 let mut names = Vec::new();
-                $(
-                let TypeInfo { name, import } = $T::type_input();
+                let TypeInfo { name, import } = $T1::type_input();
                 names.push(name);
                 merged.extend(import);
+                $(
+                    let TypeInfo { name, import } = $T::type_input();
+                    names.push(name);
+                    merged.extend(import);
                 )*
                 TypeInfo {
                     name: format!("tuple[{}]", names.join(", ")),
@@ -168,6 +174,7 @@ macro_rules! impl_tuple {
     };
 }
 
+impl_tuple!(T1);
 impl_tuple!(T1, T2);
 impl_tuple!(T1, T2, T3);
 impl_tuple!(T1, T2, T3, T4);


### PR DESCRIPTION
Example of previously non-working case:
```rust
use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
use pyo3::prelude::*;

#[gen_stub_pyclass]
struct MyStruct(u32);

#[gen_stub_pymethods]
impl MyStruct {
    fn __getnewargs__(&self) -> PyResult<(u32,)> {
        Ok((0,))
    }
}
```