### PR TITLE
test: Adds test-cases for kwargs / args

### DIFF
--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -241,6 +241,16 @@ def echo_path(path:builtins.str | os.PathLike | pathlib.Path) -> pathlib.Path: .
 
 def fn_override_type(cb:collections.abc.Callable[[str]]) -> collections.abc.Callable[[str]]: ...
 
+def func_with_kwargs(**kwargs) -> builtins.bool:
+    r"""
+    Takes a variable number of keyword arguments and do nothing
+    """
+
+def func_with_star_arg(*args) -> builtins.str:
+    r"""
+    Takes a variable number of arguments and returns their string representation.
+    """
+
 @typing.overload
 def overload_example_1(x:builtins.int) -> builtins.int: ...
 

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -539,6 +539,24 @@ submit! {
     }
 }
 
+// These are the tests to test the treatment of `*args` and `**kwargs` in functions
+
+/// Takes a variable number of arguments and returns their string representation.
+#[gen_stub_pyfunction]
+#[pyfunction]
+#[pyo3(signature = (*args))]
+fn func_with_star_arg(args: &Bound<PyTuple>) -> String {
+    args.to_string()
+}
+
+/// Takes a variable number of keyword arguments and do nothing
+#[gen_stub_pyfunction]
+#[pyfunction]
+#[pyo3(signature = (**kwargs))]
+fn func_with_kwargs(kwargs: Option<&Bound<PyDict>>) -> bool {
+    kwargs.is_some()
+}
+
 /// Initializes the Python module
 #[pymodule]
 fn pure(m: &Bound<PyModule>) -> PyResult<()> {
@@ -569,6 +587,9 @@ fn pure(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(fn_override_type, m)?)?;
     m.add_function(wrap_pyfunction!(overload_example_1, m)?)?;
     m.add_function(wrap_pyfunction!(overload_example_2, m)?)?;
+    // Test-cases for `*args` and `**kwargs`
+    m.add_function(wrap_pyfunction!(func_with_star_arg, m)?)?;
+    m.add_function(wrap_pyfunction!(func_with_kwargs, m)?)?;
     Ok(())
 }
 


### PR DESCRIPTION
Eventually fixes #259, but this contains only a reproducer for `*args` and `**kwargs`.