### PR TITLE
Add gen_stub_type_union_enum for FromPyObject with enum values

### DIFF
--- a/pyo3-stub-gen-derive/src/gen_stub.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub.rs
@@ -82,6 +82,7 @@ mod pymethods;
 mod renaming;
 mod signature;
 mod stub_type;
+mod type_union_enum;
 mod util;
 mod variant;
 
@@ -97,6 +98,7 @@ use pymethods::*;
 use renaming::*;
 use signature::*;
 use stub_type::*;
+use type_union_enum::*;
 use util::*;
 
 use proc_macro2::TokenStream as TokenStream2;
@@ -131,6 +133,18 @@ pub fn pyclass_enum(item: TokenStream2) -> Result<TokenStream2> {
 
 pub fn pyclass_complex_enum(item: TokenStream2) -> Result<TokenStream2> {
     let inner = PyComplexEnumInfo::try_from(parse2::<ItemEnum>(item.clone())?)?;
+    let derive_stub_type = StubType::from(&inner);
+    Ok(quote! {
+        #item
+        #derive_stub_type
+        pyo3_stub_gen::inventory::submit! {
+            #inner
+        }
+    })
+}
+
+pub fn type_union_enum(item: TokenStream2) -> Result<TokenStream2> {
+    let inner = TypeUnionEnumInfo::try_from(parse2::<ItemEnum>(item.clone())?)?;
     let derive_stub_type = StubType::from(&inner);
     Ok(quote! {
         #item

--- a/pyo3-stub-gen-derive/src/gen_stub/type_union_enum.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/type_union_enum.rs
@@ -1,0 +1,144 @@
+use super::{extract_documents, StubType};
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::{parse_quote, spanned::Spanned, Error, Fields, ItemEnum, Result, Type};
+
+pub struct TypeUnionEnumInfo {
+    pyclass_name: String,
+    enum_type: Type,
+    variants: Vec<Type>,
+    doc: String,
+}
+
+impl From<&TypeUnionEnumInfo> for StubType {
+    fn from(info: &TypeUnionEnumInfo) -> Self {
+        let TypeUnionEnumInfo {
+            pyclass_name,
+            enum_type,
+            ..
+        } = info;
+        Self {
+            ty: enum_type.clone(),
+            name: pyclass_name.clone(),
+            module: None,
+        }
+    }
+}
+
+impl TryFrom<ItemEnum> for TypeUnionEnumInfo {
+    type Error = Error;
+
+    fn try_from(item: ItemEnum) -> Result<Self> {
+        let ItemEnum {
+            variants,
+            attrs,
+            ident,
+            ..
+        } = item;
+
+        let doc = extract_documents(&attrs).join("\n");
+
+        let enum_type = parse_quote!(#ident);
+        let pyclass_name = ident.clone().to_string();
+
+        let variants = variants
+            .into_iter()
+            .map(|var| -> Result<Type> {
+                let var_span = var.span();
+                let Fields::Unnamed(fields) = var.fields else {
+                    return Err(syn::Error::new(
+                        var_span,
+                        "Enum variant must be 1-tuple".to_owned(),
+                    ));
+                };
+
+                if fields.unnamed.len() != 1 {
+                    return Err(syn::Error::new(
+                        var_span,
+                        "Enum variant must be 1-tuple".to_owned(),
+                    ));
+                }
+
+                let variant_type = fields.unnamed[0].ty.clone();
+                Ok(variant_type)
+            })
+            .collect::<Result<Vec<Type>>>()?;
+
+        Ok(Self {
+            doc,
+            enum_type,
+            pyclass_name,
+            variants,
+        })
+    }
+}
+
+impl ToTokens for TypeUnionEnumInfo {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let Self {
+            pyclass_name,
+            enum_type,
+            variants,
+            doc,
+            ..
+        } = self;
+
+        let variants = variants.iter().map(|variant_type| {
+            quote! {<#variant_type as pyo3_stub_gen::PyStubType>::type_output}
+        });
+        tokens.append_all(quote! {
+            ::pyo3_stub_gen::type_info::TypeUnionEnumInfo {
+                pyclass_name: #pyclass_name,
+                enum_id: std::any::TypeId::of::<#enum_type>,
+                variants: &[ #( #variants ),* ],
+                doc: #doc,
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use syn::parse_str;
+
+    #[test]
+    fn test() -> Result<()> {
+        let input: ItemEnum = parse_str(
+            r#"
+            #[derive(FromPyObject)]
+            pub enum FunctionAgg {
+                S(String),
+                I(i32),
+                F(f32),
+            }
+            "#,
+        )?;
+        let out = TypeUnionEnumInfo::try_from(input)?.to_token_stream();
+        insta::assert_snapshot!(format_as_value(out), @r#"
+        ::pyo3_stub_gen::type_info::TypeUnionEnumInfo {
+            pyclass_name: "FunctionAgg",
+            enum_id: std::any::TypeId::of::<FunctionAgg>,
+            variants: &[
+                <String as pyo3_stub_gen::PyStubType>::type_output,
+                <i32 as pyo3_stub_gen::PyStubType>::type_output,
+                <f32 as pyo3_stub_gen::PyStubType>::type_output,
+            ],
+            doc: "",
+        }
+        "#);
+        Ok(())
+    }
+
+    fn format_as_value(tt: TokenStream2) -> String {
+        let ttt = quote! { const _: () = #tt; };
+        let formatted = prettyplease::unparse(&syn::parse_file(&ttt.to_string()).unwrap());
+        formatted
+            .trim()
+            .strip_prefix("const _: () = ")
+            .unwrap()
+            .strip_suffix(';')
+            .unwrap()
+            .to_string()
+    }
+}

--- a/pyo3-stub-gen-derive/src/lib.rs
+++ b/pyo3-stub-gen-derive/src/lib.rs
@@ -65,6 +65,25 @@ pub fn gen_stub_pyclass_complex_enum(_attr: TokenStream, item: TokenStream) -> T
         .into()
 }
 
+/// Embed metadata for Python stub file generation for `#[derive(FromPyObject)]` macro with an enum
+/// of different types
+///
+/// ```
+/// #[pyo3_stub_gen_derive::gen_stub_type_union_enum]
+/// #[derive(pyo3::FromPyObject)]
+/// pub enum FunctionAgg {
+///     S(String),
+///     I(i32),
+///     F(f32),
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn gen_stub_type_union_enum(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    gen_stub::type_union_enum(item.into())
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
 /// Embed metadata for Python stub file generation for `#[pymethods]` macro
 ///
 /// ```

--- a/pyo3-stub-gen/src/generate.rs
+++ b/pyo3-stub-gen/src/generate.rs
@@ -11,6 +11,7 @@ mod member;
 mod method;
 mod module;
 mod stub_info;
+mod union;
 mod variable;
 mod variant_methods;
 
@@ -23,6 +24,7 @@ pub use member::*;
 pub use method::*;
 pub use module::*;
 pub use stub_info::*;
+pub use union::*;
 pub use variable::*;
 
 use crate::stub_type::ModuleRef;

--- a/pyo3-stub-gen/src/generate/module.rs
+++ b/pyo3-stub-gen/src/generate/module.rs
@@ -11,6 +11,7 @@ use std::{
 pub struct Module {
     pub class: BTreeMap<TypeId, ClassDef>,
     pub enum_: BTreeMap<TypeId, EnumDef>,
+    pub type_union: BTreeMap<TypeId, TypeUnionDef>,
     pub function: BTreeMap<&'static str, Vec<FunctionDef>>,
     pub error: BTreeMap<&'static str, ErrorDef>,
     pub variables: BTreeMap<&'static str, VariableDef>,
@@ -66,6 +67,9 @@ impl fmt::Display for Module {
         }
         for enum_ in self.enum_.values().sorted_by_key(|class| class.name) {
             write!(f, "{enum_}")?;
+        }
+        for type_union in self.type_union.values().sorted_by_key(|class| class.name) {
+            write!(f, "{type_union}")?;
         }
         for functions in self.function.values() {
             let overloaded = functions.len() > 1;

--- a/pyo3-stub-gen/src/generate/stub_info.rs
+++ b/pyo3-stub-gen/src/generate/stub_info.rs
@@ -118,6 +118,12 @@ impl StubInfoBuilder {
             .insert((info.enum_id)(), ClassDef::from(info));
     }
 
+    fn add_type_union_enum(&mut self, info: &TypeUnionEnumInfo) {
+        self.get_module(None)
+            .type_union
+            .insert((info.enum_id)(), TypeUnionDef::from(info));
+    }
+
     fn add_enum(&mut self, info: &PyEnumInfo) {
         self.get_module(info.module)
             .enum_
@@ -224,6 +230,9 @@ impl StubInfoBuilder {
         }
         for info in inventory::iter::<PyComplexEnumInfo> {
             self.add_complex_enum(info);
+        }
+        for info in inventory::iter::<TypeUnionEnumInfo> {
+            self.add_type_union_enum(info);
         }
         for info in inventory::iter::<PyEnumInfo> {
             self.add_enum(info);

--- a/pyo3-stub-gen/src/generate/union.rs
+++ b/pyo3-stub-gen/src/generate/union.rs
@@ -1,0 +1,42 @@
+use crate::{generate::*, type_info::*, TypeInfo};
+use std::fmt;
+
+/// Definition of a Python enum.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeUnionDef {
+    pub name: &'static str,
+    pub doc: &'static str,
+    pub variants: Vec<TypeInfo>,
+}
+
+impl From<&TypeUnionEnumInfo> for TypeUnionDef {
+    fn from(info: &TypeUnionEnumInfo) -> Self {
+        Self {
+            name: info.pyclass_name,
+            doc: info.doc,
+            variants: info.variants.iter().map(|t| t()).collect(),
+        }
+    }
+}
+
+impl fmt::Display for TypeUnionDef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} = ", self.name)?;
+        let indent = indent();
+
+        for (i, variant_name) in self.variants.iter().enumerate() {
+            if i != 0 {
+                write!(f, " | ")?;
+            }
+            write!(f, "{variant_name}")?;
+        }
+        writeln!(f, "\n")?;
+
+        // Docstrings don't really seem to be supported, but pyright uses mult-line strings below
+        // definition:
+        // https://discuss.python.org/t/docstrings-for-new-type-aliases-as-defined-in-pep-695/39816
+        docstring::write_docstring(f, self.doc, indent)?;
+
+        Ok(())
+    }
+}

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -177,6 +177,21 @@ pub struct PyComplexEnumInfo {
 
 inventory::collect!(PyComplexEnumInfo);
 
+/// Info of a `#[pyclass]` with a rich (structured) Rust enum
+#[derive(Debug)]
+pub struct TypeUnionEnumInfo {
+    // Rust struct type-id
+    pub enum_id: fn() -> TypeId,
+    // The name exposed to Python
+    pub pyclass_name: &'static str,
+    /// Docstring
+    pub doc: &'static str,
+    /// types of union variants
+    pub variants: &'static [fn() -> TypeInfo],
+}
+
+inventory::collect!(TypeUnionEnumInfo);
+
 /// Info of `#[pyclass]` with Rust enum
 #[derive(Debug)]
 pub struct PyEnumInfo {


### PR DESCRIPTION
Motivation: I sometimes want arguments to my functions to accept multiple different types, e.g. a list of ints or an int. For this I use `derive(FromPyObject)` with an enum wrapper. Example:

```rust
#[derive(pyo3::FromPyObject)]
#[pyo3_stub_gen::???]
enum IntOrListOfInts {
    Int(i32),
    ListOfInts(Vec<i32>),
}
#[pyo3::pyfunction]
#[pyo3_stub_gen::gen_stub_pyfunction]
fn my_function(arg: IntOrListOfInts) { ... }
```

The options for stub generation (enum or complex enum) don't quite work for this, though. So this PR adds the macro `gen_stub_type_union_enum` which when applied to IntOrListOfInts generates
```
IntOrListOfInts = builtins.int | builtins.list[builtins.int]
def my_function(arg: IntOrListOfInts):
    ...
```
which makes pyright happy.

Since this code base has quite a few moving parts, I'm not 100% I implemented everything as it should be. It seems to work for my usecase at least, though. Feel free to ask me to fix/add things.