### PR TITLE
fix: Correct ellipsis placement for type_ignore without docstrings

### DIFF
--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -355,6 +355,10 @@ def test_type_ignore_custom() -> builtins.int:  # type: ignore[custom-rule,attr-
     Test function with custom (unknown) rule
     """
 
+def test_type_ignore_no_comment_all() -> builtins.int: ...  # type: ignore
+
+def test_type_ignore_no_comment_specific() -> builtins.int: ...  # type: ignore[arg-type,reportIncompatibleMethodOverride]
+
 def test_type_ignore_pyright() -> builtins.int:  # type: ignore[reportGeneralTypeIssues,reportReturnType]
     r"""
     Test function with Pyright diagnostic rules

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -642,6 +642,8 @@ fn pure(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(test_type_ignore_all, m)?)?;
     m.add_function(wrap_pyfunction!(test_type_ignore_pyright, m)?)?;
     m.add_function(wrap_pyfunction!(test_type_ignore_custom, m)?)?;
+    m.add_function(wrap_pyfunction!(test_type_ignore_no_comment_all, m)?)?;
+    m.add_function(wrap_pyfunction!(test_type_ignore_no_comment_specific, m)?)?;
 
     // Test case for custom exceptions
     m.add("MyError", m.py().get_type::<MyError>())?;
@@ -681,6 +683,24 @@ fn test_type_ignore_pyright() -> i32 {
 #[gen_stub(type_ignore = ["custom-rule", "attr-defined"])]
 #[pyfunction]
 fn test_type_ignore_custom() -> i32 {
+    42
+}
+
+// NOTE: Doc-comment MUST NOT be added to the next function,
+// as it tests if `type_ignore` without no doccomment is handled correctly;
+// i.e. it emits comment after `...`, not before.
+
+#[gen_stub_pyfunction]
+#[gen_stub(type_ignore)]
+#[pyfunction]
+fn test_type_ignore_no_comment_all() -> i32 {
+    42
+}
+
+#[gen_stub_pyfunction]
+#[gen_stub(type_ignore=["arg-type", "reportIncompatibleMethodOverride"])]
+#[pyfunction]
+fn test_type_ignore_no_comment_specific() -> i32 {
     42
 }
 

--- a/pyo3-stub-gen/src/generate/function.rs
+++ b/pyo3-stub-gen/src/generate/function.rs
@@ -62,9 +62,7 @@ impl fmt::Display for FunctionDef {
         // Calculate type: ignore comment once
         let type_ignore_comment = if let Some(target) = &self.type_ignored {
             match target {
-                IgnoreTarget::All => {
-                    Some("  # type: ignore".to_string())
-                }
+                IgnoreTarget::All => Some("  # type: ignore".to_string()),
                 IgnoreTarget::Specified(rules) => {
                     let rules_str = rules
                         .iter()

--- a/pyo3-stub-gen/src/generate/function.rs
+++ b/pyo3-stub-gen/src/generate/function.rs
@@ -59,11 +59,11 @@ impl fmt::Display for FunctionDef {
         }
         write!(f, ") -> {}:", self.r#return)?;
 
-        // Add type: ignore comment if needed
-        if let Some(target) = &self.type_ignored {
+        // Calculate type: ignore comment once
+        let type_ignore_comment = if let Some(target) = &self.type_ignored {
             match target {
                 IgnoreTarget::All => {
-                    write!(f, "  # type: ignore")?;
+                    Some("  # type: ignore".to_string())
                 }
                 IgnoreTarget::Specified(rules) => {
                     let rules_str = rules
@@ -76,17 +76,28 @@ impl fmt::Display for FunctionDef {
                             result
                         })
                         .join(",");
-                    write!(f, "  # type: ignore[{}]", rules_str)?;
+                    Some(format!("  # type: ignore[{}]", rules_str))
                 }
             }
-        }
+        } else {
+            None
+        };
 
         let doc = self.doc;
         if !doc.is_empty() {
+            // Add type: ignore comment for functions with docstrings
+            if let Some(comment) = &type_ignore_comment {
+                write!(f, "{}", comment)?;
+            }
             writeln!(f)?;
             docstring::write_docstring(f, self.doc, indent())?;
         } else {
-            writeln!(f, " ...")?;
+            write!(f, " ...")?;
+            // Add type: ignore comment for functions without docstrings
+            if let Some(comment) = &type_ignore_comment {
+                write!(f, "{}", comment)?;
+            }
+            writeln!(f)?;
         }
         writeln!(f)?;
         Ok(())

--- a/pyo3-stub-gen/src/generate/method.rs
+++ b/pyo3-stub-gen/src/generate/method.rs
@@ -87,9 +87,7 @@ impl fmt::Display for MethodDef {
         // Calculate type: ignore comment once
         let type_ignore_comment = if let Some(target) = &self.type_ignored {
             match target {
-                IgnoreTarget::All => {
-                    Some("  # type: ignore".to_string())
-                }
+                IgnoreTarget::All => Some("  # type: ignore".to_string()),
                 IgnoreTarget::Specified(rules) => {
                     let rules_str = rules
                         .iter()

--- a/pyo3-stub-gen/src/generate/method.rs
+++ b/pyo3-stub-gen/src/generate/method.rs
@@ -84,11 +84,11 @@ impl fmt::Display for MethodDef {
         }
         write!(f, ") -> {}:", self.r#return)?;
 
-        // Add type: ignore comment if needed
-        if let Some(target) = &self.type_ignored {
+        // Calculate type: ignore comment once
+        let type_ignore_comment = if let Some(target) = &self.type_ignored {
             match target {
                 IgnoreTarget::All => {
-                    write!(f, "  # type: ignore")?;
+                    Some("  # type: ignore".to_string())
                 }
                 IgnoreTarget::Specified(rules) => {
                     let rules_str = rules
@@ -101,18 +101,29 @@ impl fmt::Display for MethodDef {
                             result
                         })
                         .join(",");
-                    write!(f, "  # type: ignore[{}]", rules_str)?;
+                    Some(format!("  # type: ignore[{}]", rules_str))
                 }
             }
-        }
+        } else {
+            None
+        };
 
         let doc = self.doc;
         if !doc.is_empty() {
+            // Add type: ignore comment for methods with docstrings
+            if let Some(comment) = &type_ignore_comment {
+                write!(f, "{}", comment)?;
+            }
             writeln!(f)?;
             let double_indent = format!("{indent}{indent}");
             docstring::write_docstring(f, self.doc, &double_indent)?;
         } else {
-            writeln!(f, " ...")?;
+            write!(f, " ...")?;
+            // Add type: ignore comment for methods without docstrings
+            if let Some(comment) = &type_ignore_comment {
+                write!(f, "{}", comment)?;
+            }
+            writeln!(f)?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Fix malformed stub syntax where functions/methods with `type_ignore` attributes but no docstrings generated invalid Python syntax
- Refactor to eliminate code duplication in type_ignore comment generation
- Add comprehensive test cases for edge cases

## Problem
Previously, functions without docstrings but with `#[gen_stub(type_ignore)]` generated malformed stub files:
```python
def func() -> int:  # type: ignore ...
```

## Solution
Now correctly generates valid Python syntax:
```python
def func() -> int: ...  # type: ignore
```

## Changes
- **function.rs**: Refactor Display implementation to place ellipsis before type: ignore comments
- **method.rs**: Apply same fix for methods  
- **examples/pure/src/lib.rs**: Add test functions `test_type_ignore_no_comment_all` and `test_type_ignore_no_comment_specific`
- **Both files**: Eliminate code duplication by calculating type_ignore comment once and reusing

## Test Plan
- [x] Added test cases for functions without docstrings + type_ignore (both catch-all and specific rules)
- [x] Verified existing functionality preserved (functions with docstrings still work)  
- [x] Generated stubs show correct syntax for all type_ignore scenarios
- [x] All existing tests pass (29 total)
- [x] No regressions in stub generation

🤖 Generated with [Claude Code](https://claude.ai/code)