### PR TITLE
Add #[gen_stub_pymethods_prune] macro

### DIFF
--- a/pyo3-stub-gen-derive/src/gen_stub.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub.rs
@@ -156,6 +156,14 @@ pub fn pymethods(item: TokenStream2) -> Result<TokenStream2> {
     })
 }
 
+pub fn pymethods_prune(item: TokenStream2) -> Result<TokenStream2> {
+    let mut item_impl = parse2::<ItemImpl>(item)?;
+    pymethods::prune_attrs(&mut item_impl);
+    Ok(quote! {
+        #item_impl
+    })
+}
+
 pub fn pyfunction(attr: TokenStream2, item: TokenStream2) -> Result<TokenStream2> {
     let mut item_fn = parse2::<ItemFn>(item)?;
     let mut inner = PyFunctionInfo::try_from(item_fn.clone())?;

--- a/pyo3-stub-gen-derive/src/lib.rs
+++ b/pyo3-stub-gen-derive/src/lib.rs
@@ -88,6 +88,24 @@ pub fn gen_stub_pymethods(_attr: TokenStream, item: TokenStream) -> TokenStream 
         .into()
 }
 
+/// Remove `#[gen_stub(...)]` from method blocks.
+///
+/// ```
+/// #[pyo3_stub_gen_derive::gen_stub_pymethods_prune]
+/// impl A {
+///     #[gen_stub(override_return_type(type_repr="int")]
+///     fn f(&self) -> u32 {
+///        todo!()
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn gen_stub_pymethods_prune(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    gen_stub::pymethods_prune(item.into())
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
 /// Embed metadata for Python stub file generation for `#[pyfunction]` macro
 ///
 /// ```


### PR DESCRIPTION
Add the `#[gen_stub_pymethods_prune]`, which is a solution to #266.