### PR TITLE
Feature gating `infer_signature`, fix #283, perhaps fix #161

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,6 +60,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: Run tests (no default features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features -p pyo3-stub-gen
 
   semver-check:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "mixed"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "env_logger",
  "pyo3",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "mixed_sub"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "env_logger",
  "pyo3",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "mixed_sub_multiple"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "env_logger",
  "pyo3",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "pure"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "ahash",
  "env_logger",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen-derive"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "heck",
  "insta",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "test-dash-package"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "pyo3",
  "pyo3-stub-gen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 
 description = "Stub file (*.pyi) generator for PyO3"

--- a/pyo3-stub-gen-derive/src/gen_stub/member.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/member.rs
@@ -198,11 +198,8 @@ impl ToTokens for MemberInfo {
                     let (TypeOrOverride::RustType { r#type: ty }
                     | TypeOrOverride::OverrideType { r#type: ty, .. }) = r#type;
                     quote! {
-                        ::pyo3::prepare_freethreaded_python();
-                        ::pyo3::Python::with_gil(|py| -> String {
-                            let v: #ty = #value;
-                            ::pyo3_stub_gen::util::fmt_py_obj(py, v)
-                        })
+                    let v: #ty = #value;
+                    ::pyo3_stub_gen::util::fmt_py_obj(v)
                     }
                 }
             })

--- a/pyo3-stub-gen-derive/src/gen_stub/pyclass_complex_enum.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyclass_complex_enum.rs
@@ -181,11 +181,8 @@ mod test {
                                 default: {
                                     static DEFAULT: std::sync::LazyLock<String> = std::sync::LazyLock::new(||
                                     {
-                                        ::pyo3::prepare_freethreaded_python();
-                                        ::pyo3::Python::with_gil(|py| -> String {
-                                            let v: f64 = 1.0;
-                                            ::pyo3_stub_gen::util::fmt_py_obj(py, v)
-                                        })
+                                        let v: f64 = 1.0;
+                                        ::pyo3_stub_gen::util::fmt_py_obj(v)
                                     });
                                     &DEFAULT
                                 },

--- a/pyo3-stub-gen-derive/src/gen_stub/signature.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/signature.rs
@@ -125,11 +125,8 @@ impl ToTokens for ArgsWithSignature<'_> {
                                 }
                             } else {
                                 quote! {
-                                ::pyo3::prepare_freethreaded_python();
-                                ::pyo3::Python::with_gil(|py| -> String {
-                                    let v: #r#type = #value;
-                                    ::pyo3_stub_gen::util::fmt_py_obj(py, v)
-                                })
+                                let v: #r#type = #value;
+                                ::pyo3_stub_gen::util::fmt_py_obj(v)
                                 }
                             };
                             Ok(quote! {
@@ -154,11 +151,8 @@ impl ToTokens for ArgsWithSignature<'_> {
                                 }
                             } else {
                                 quote! {
-                                ::pyo3::prepare_freethreaded_python();
-                                ::pyo3::Python::with_gil(|py| -> String {
-                                    let v: #r#type = #value;
-                                    ::pyo3_stub_gen::util::fmt_py_obj(py, v)
-                                })
+                                let v: #r#type = #value;
+                                ::pyo3_stub_gen::util::fmt_py_obj(v)
                                 }
                             };
                             Ok(quote! {

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -31,6 +31,7 @@ path = "../pyo3-stub-gen-derive"
 test-case.workspace = true
 
 [features]
-default = ["numpy", "either"]
+default = ["numpy", "either", "infer_signature"]
 numpy = ["dep:numpy"]
 either = ["dep:either"]
+infer_signature = []

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -24,7 +24,7 @@ serde.workspace = true
 toml.workspace = true
 
 [dependencies.pyo3-stub-gen-derive]
-version = "0.13.2"
+version = "0.14.0"
 path = "../pyo3-stub-gen-derive"
 
 [dev-dependencies]

--- a/pyo3-stub-gen/src/util.rs
+++ b/pyo3-stub-gen/src/util.rs
@@ -52,15 +52,25 @@ fn get_globals<'py>(any: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyDict>> {
     Ok(globals)
 }
 
-pub fn fmt_py_obj<'py, T: pyo3::IntoPyObjectExt<'py>>(py: Python<'py>, obj: T) -> String {
-    if let Ok(any) = obj.into_bound_py_any(py) {
-        if all_builtin_types(&any) || valid_external_repr(&any).is_some_and(|valid| valid) {
-            if let Ok(py_str) = any.repr() {
-                return py_str.to_string();
+pub fn fmt_py_obj<T: for<'py> pyo3::IntoPyObjectExt<'py>>(obj: T) -> String {
+    #[cfg(feature = "infer_signature")]
+    {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| -> String {
+            if let Ok(any) = obj.into_bound_py_any(py) {
+                if all_builtin_types(&any) || valid_external_repr(&any).is_some_and(|valid| valid) {
+                    if let Ok(py_str) = any.repr() {
+                        return py_str.to_string();
+                    }
+                }
             }
-        }
+            "...".to_owned()
+        })
     }
-    "...".to_owned()
+    #[cfg(not(feature = "infer_signature"))]
+    {
+        "...".to_owned()
+    }
 }
 
 #[cfg(test)]
@@ -72,61 +82,58 @@ mod test {
     #[test]
     fn test_fmt_dict() {
         pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::with_gil(|py| {
             let dict = PyDict::new(py);
             _ = dict.set_item("k1", "v1");
             _ = dict.set_item("k2", 2);
-            assert_eq!("{'k1': 'v1', 'k2': 2}", fmt_py_obj(py, &dict));
+            assert_eq!("{'k1': 'v1', 'k2': 2}", fmt_py_obj(dict.as_unbound()));
             // class A variable can not be formatted
             _ = dict.set_item("k3", A {});
-            assert_eq!("...", fmt_py_obj(py, &dict));
+            assert_eq!("...", fmt_py_obj(dict.as_unbound()));
         })
     }
     #[test]
     fn test_fmt_list() {
         pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::with_gil(|py| {
             let list = PyList::new(py, [1, 2]).unwrap();
-            assert_eq!("[1, 2]", fmt_py_obj(py, &list));
+            assert_eq!("[1, 2]", fmt_py_obj(list.as_unbound()));
             // class A variable can not be formatted
             let list = PyList::new(py, [A {}, A {}]).unwrap();
-            assert_eq!("...", fmt_py_obj(py, &list));
+            assert_eq!("...", fmt_py_obj(list.as_unbound()));
         })
     }
     #[test]
     fn test_fmt_tuple() {
         pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
+        pyo3::Python::with_gil(|py| {
             let tuple = PyTuple::new(py, [1, 2]).unwrap();
-            assert_eq!("(1, 2)", fmt_py_obj(py, tuple));
+            assert_eq!("(1, 2)", fmt_py_obj(tuple.as_unbound()));
             let tuple = PyTuple::new(py, [1]).unwrap();
-            assert_eq!("(1,)", fmt_py_obj(py, tuple));
+            assert_eq!("(1,)", fmt_py_obj(tuple.as_unbound()));
             // class A variable can not be formatted
             let tuple = PyTuple::new(py, [A {}]).unwrap();
-            assert_eq!("...", fmt_py_obj(py, tuple));
+            assert_eq!("...", fmt_py_obj(tuple.as_unbound()));
         })
     }
     #[test]
     fn test_fmt_other() {
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            // str
-            assert_eq!("'123'", fmt_py_obj(py, "123"));
-            assert_eq!("\"don't\"", fmt_py_obj(py, "don't"));
-            assert_eq!("'str\\\\'", fmt_py_obj(py, "str\\"));
-            // bool
-            assert_eq!("True", fmt_py_obj(py, true));
-            assert_eq!("False", fmt_py_obj(py, false));
-            // int
-            assert_eq!("123", fmt_py_obj(py, 123));
-            // float
-            assert_eq!("1.23", fmt_py_obj(py, 1.23));
-            // None
-            let none: Option<usize> = None;
-            assert_eq!("None", fmt_py_obj(py, none));
-            // class A variable can not be formatted
-            assert_eq!("...", fmt_py_obj(py, A {}));
-        })
+        // str
+        assert_eq!("'123'", fmt_py_obj("123"));
+        assert_eq!("\"don't\"", fmt_py_obj("don't"));
+        assert_eq!("'str\\\\'", fmt_py_obj("str\\"));
+        // bool
+        assert_eq!("True", fmt_py_obj(true));
+        assert_eq!("False", fmt_py_obj(false));
+        // int
+        assert_eq!("123", fmt_py_obj(123));
+        // float
+        assert_eq!("1.23", fmt_py_obj(1.23));
+        // None
+        let none: Option<usize> = None;
+        assert_eq!("None", fmt_py_obj(none));
+        // class A variable can not be formatted
+        assert_eq!("...", fmt_py_obj(A {}));
     }
     #[test]
     fn test_fmt_enum() {
@@ -136,9 +143,6 @@ mod test {
             Float,
             Integer,
         }
-        pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| {
-            assert_eq!("Number.Float", fmt_py_obj(py, Number::Float));
-        });
+        assert_eq!("Number.Float", fmt_py_obj(Number::Float));
     }
 }

--- a/pyo3-stub-gen/src/util.rs
+++ b/pyo3-stub-gen/src/util.rs
@@ -52,6 +52,7 @@ fn get_globals<'py>(any: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyDict>> {
     Ok(globals)
 }
 
+#[cfg_attr(not(feature = "infer_signature"), allow(unused_variables))]
 pub fn fmt_py_obj<T: for<'py> pyo3::IntoPyObjectExt<'py>>(obj: T) -> String {
     #[cfg(feature = "infer_signature")]
     {
@@ -73,7 +74,7 @@ pub fn fmt_py_obj<T: for<'py> pyo3::IntoPyObjectExt<'py>>(obj: T) -> String {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "infer_signature"))]
 mod test {
     use super::*;
     #[pyclass]


### PR DESCRIPTION
Now we use `pyo3::prepare_freethreaded_python` and `pyo3::Python::with_gil` for signature inferrence, which can cause linker errors in some special `extension-module` cases.

This PR introduces `infer_signature` to control whether or not using signature inferrence. Turn off `infer_signature` manually can avoid a lot of linker errors.