### PR TITLE
Write type of *args

### DIFF
--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -304,7 +304,12 @@ def func_with_kwargs(**kwargs) -> builtins.bool:
     Takes a variable number of keyword arguments and does nothing
     """
 
-def func_with_star_arg(*args) -> builtins.str:
+def func_with_star_arg(*args:tuple) -> builtins.str:
+    r"""
+    Takes a variable number of arguments and returns their string representation.
+    """
+
+def func_with_star_arg_typed(*args:str) -> builtins.str:
     r"""
     Takes a variable number of arguments and returns their string representation.
     """

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -590,6 +590,16 @@ impl HashableStruct {
 #[gen_stub_pyfunction]
 #[pyfunction]
 #[pyo3(signature = (*args))]
+fn func_with_star_arg_typed(
+    #[gen_stub(override_type(type_repr = "str"))] args: &Bound<PyTuple>,
+) -> String {
+    args.to_string()
+}
+
+/// Takes a variable number of arguments and returns their string representation.
+#[gen_stub_pyfunction]
+#[pyfunction]
+#[pyo3(signature = (*args))]
 fn func_with_star_arg(args: &Bound<PyTuple>) -> String {
     args.to_string()
 }
@@ -635,6 +645,7 @@ fn pure(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(overload_example_2, m)?)?;
     // Test-cases for `*args` and `**kwargs`
     m.add_function(wrap_pyfunction!(func_with_star_arg, m)?)?;
+    m.add_function(wrap_pyfunction!(func_with_star_arg_typed, m)?)?;
     m.add_function(wrap_pyfunction!(func_with_kwargs, m)?)?;
 
     // Test cases for type: ignore functionality

--- a/pyo3-stub-gen/src/generate/arg.rs
+++ b/pyo3-stub-gen/src/generate/arg.rs
@@ -34,7 +34,7 @@ impl fmt::Display for Arg {
                     write!(f, "{}:{}={}", self.name, self.r#type, default)
                 }
                 SignatureArg::Star => write!(f, "*"),
-                SignatureArg::Args => write!(f, "*{}", self.name),
+                SignatureArg::Args => write!(f, "*{}:{}", self.name, self.r#type),
                 SignatureArg::Keywords => write!(f, "**{}", self.name),
             }
         } else {


### PR DESCRIPTION
Write the type of `*args` if it is specified:
```rust
/// Takes a variable number of arguments and returns their string representation.
#[gen_stub_pyfunction]
#[pyfunction]
#[pyo3(signature = (*args))]
fn func_with_star_arg(args: &Bound<PyTuple>) -> String {
    args.to_string()
}

#[gen_stub_pyfunction]
#[pyfunction]
#[pyo3(signature = (*args))]
fn func_with_star_arg_typed(
    #[gen_stub(override_type(type_repr = "str"))] args: &Bound<PyTuple>,
) -> String {
    args.to_string()
}
```

yields

```python
def func_with_star_arg(*args:tuple) -> builtins.str:
    r"""
    Takes a variable number of arguments and returns their string representation.
    """

def func_with_star_arg_typed(*args:str) -> builtins.str:
    r"""
    Takes a variable number of arguments and returns their string representation.
    """
```