### PR TITLE
Remove `PyEncodingWarning`, which is only available in Python 3.10

### DIFF
--- a/pyo3-stub-gen/src/exception.rs
+++ b/pyo3-stub-gen/src/exception.rs
@@ -66,7 +66,8 @@ impl_exception_stub_type!(PyConnectionRefusedError, "ConnectionRefusedError");
 impl_exception_stub_type!(PyConnectionResetError, "ConnectionResetError");
 impl_exception_stub_type!(PyDeprecationWarning, "DeprecationWarning");
 impl_exception_stub_type!(PyEOFError, "EOFError");
-impl_exception_stub_type!(PyEncodingWarning, "EncodingWarning");
+// FIXME: PyEncodingWarning is only for Py_3_10
+// impl_exception_stub_type!(PyEncodingWarning, "EncodingWarning");
 impl_exception_stub_type!(PyEnvironmentError, "EnvironmentError");
 impl_exception_stub_type!(PyException, "Exception");
 impl_exception_stub_type!(PyFileExistsError, "FileExistsError");


### PR DESCRIPTION
`PyEncodingWarning` is only available in Python 3.10
https://github.com/PyO3/pyo3/blob/a4a202d951551d1b63b23d3b365409c3489a8410/src/exceptions.rs#L741-L746

It seems no better way to avoid error while keep `PyEncodingWarning`.