### PR TITLE
Add support for numpy bool types

### DIFF
--- a/pyo3-stub-gen/src/stub_type/numpy.rs
+++ b/pyo3-stub-gen/src/stub_type/numpy.rs
@@ -22,6 +22,7 @@ macro_rules! impl_numpy_scalar {
     };
 }
 
+impl_numpy_scalar!(bool, "bool");
 impl_numpy_scalar!(i8, "int8");
 impl_numpy_scalar!(i16, "int16");
 impl_numpy_scalar!(i32, "int32");


### PR DESCRIPTION
Numpy 2 has blessed the type numpy.bool so it can be used in type hints

This addresses part of #97. This issue coudl probably be updated since:
- int16 and uint16 are already supported
- bfloat16 is not supported by Numpy
- f16 is not stable as of Rust 1.89
- isize and usize could be supported

I did not find any tests related to numpy types, but I can add some if pointed to the right direction.