### PR TITLE
feat: Add support for `ordered_float::NotNan`, `ordered_float::OrderedFloat` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +613,7 @@ dependencies = [
  "maplit",
  "num-complex",
  "numpy",
+ "ordered-float",
  "pyo3",
  "pyo3-stub-gen-derive",
  "rust_decimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,9 +485,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "ordered-float"
-version = "4.6.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ log = "0.4.28"
 maplit = "1.0.2"
 num-complex = "0.4.6"
 numpy = ">= 0.26.0"
+ordered-float = { version = "4.0", default-features = false }
 prettyplease = "0.2.37"
 proc-macro2 = "1.0.101"
 pyo3 = ">= 0.26.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ log = "0.4.28"
 maplit = "1.0.2"
 num-complex = "0.4.6"
 numpy = ">= 0.26.0"
-ordered-float = { version = "4.0", default-features = false }
+ordered-float = { version = "5.0", default-features = false }
 prettyplease = "0.2.37"
 proc-macro2 = "1.0.101"
 pyo3 = ">= 0.26.0"

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -19,6 +19,7 @@ maplit.workspace = true
 num-complex.workspace = true
 numpy = { workspace = true, optional = true }
 either = { workspace = true, optional = true }
+ordered-float = { workspace = true, optional = true }
 pyo3.workspace = true
 rust_decimal = { workspace = true, optional = true }
 serde.workspace = true
@@ -32,8 +33,9 @@ path = "../pyo3-stub-gen-derive"
 test-case.workspace = true
 
 [features]
-default = ["numpy", "either", "infer_signature"]
+default = ["numpy", "either", "infer_signature", "ordered-float"]
 numpy = ["dep:numpy"]
 either = ["dep:either"]
 infer_signature = []
+ordered-float = ["dep:ordered-float"]
 rust_decimal = ["dep:rust_decimal"]

--- a/pyo3-stub-gen/src/stub_type/builtins.rs
+++ b/pyo3-stub-gen/src/stub_type/builtins.rs
@@ -65,6 +65,15 @@ impl_builtin!(Cow<'_, str>, "str");
 impl_builtin!(Cow<'_, OsStr>, "str");
 impl_builtin!(Cow<'_, [u8]>, "bytes");
 
+#[cfg(feature = "ordered-float")]
+mod impl_ordered_float {
+    use super::*;
+    impl_builtin!(ordered_float::NotNan<f32>, "float");
+    impl_builtin!(ordered_float::NotNan<f64>, "float");
+    impl_builtin!(ordered_float::OrderedFloat<f32>, "float");
+    impl_builtin!(ordered_float::OrderedFloat<f64>, "float");
+}
+
 impl PyStubType for PathBuf {
     fn type_output() -> TypeInfo {
         TypeInfo::with_module("pathlib.Path", "pathlib".into())


### PR DESCRIPTION
[ordered-float](https://crates.io/crates/ordered-float) provides several wrapper types (`NotNan`, `OrderedFloat`) for `Hash`, `Ord` and `Eq` implementations on f64 and f32.
Hope we can support those types, thanks a lot!

