### PR TITLE
added a cfg flag to a Python >=3.10 exclusive exception

### DIFF
--- a/pyo3-stub-gen/src/exception.rs
+++ b/pyo3-stub-gen/src/exception.rs
@@ -66,6 +66,7 @@ impl_exception_stub_type!(PyConnectionRefusedError, "ConnectionRefusedError");
 impl_exception_stub_type!(PyConnectionResetError, "ConnectionResetError");
 impl_exception_stub_type!(PyDeprecationWarning, "DeprecationWarning");
 impl_exception_stub_type!(PyEOFError, "EOFError");
+#[cfg(Py_3_10)]
 impl_exception_stub_type!(PyEncodingWarning, "EncodingWarning");
 impl_exception_stub_type!(PyEnvironmentError, "EnvironmentError");
 impl_exception_stub_type!(PyException, "Exception");


### PR DESCRIPTION
Hey and just in advance, very sorry if i am wrong about this, I am very inexperienced with rust and pyo3 even more,

"PyEncodingWarning" appears to be a python >=3.10 exclusive exception which is giving compile errors for any python version older than that.

but in my personal project, adding this flag allowed it to compile to python 3.7 fine.