### PR TITLE
Add missing implementation for builtin bool type

### DIFF
--- a/pyo3-stub-gen/src/stub_type/pyo3.rs
+++ b/pyo3-stub-gen/src/stub_type/pyo3.rs
@@ -66,6 +66,7 @@ macro_rules! impl_builtin {
     };
 }
 
+impl_builtin!(PyBool, "bool");
 impl_builtin!(PyInt, "int");
 impl_builtin!(PyFloat, "float");
 impl_builtin!(PyComplex, "complex");


### PR DESCRIPTION
This PR adds the missing implementation for the builtin boolean type defined by `pyo3`.