### PR TITLE
Create __init__.pyi if module directory exists

### DIFF
--- a/pyo3-stub-gen/src/generate/stub_info.rs
+++ b/pyo3-stub-gen/src/generate/stub_info.rs
@@ -33,7 +33,7 @@ impl StubInfo {
             // Convert dashes to underscores for Python compatibility
             let normalized_name = name.replace("-", "_");
             let path = normalized_name.replace(".", "/");
-            let dest = if module.submodules.is_empty() && !self.python_root.join(&path).exists() {
+            let dest = if module.submodules.is_empty() && !self.python_root.join(&path).is_dir() {
                 self.python_root.join(format!("{path}.pyi"))
             } else {
                 self.python_root.join(path).join("__init__.pyi")


### PR DESCRIPTION
Create a `submodule/__init__.pyi` file instead of `submodule.pyi` if the directory `submodule` exists. This allows for precreating a project hierarchy with directories, that is better understood by pylance and other static analysis tools (without an explicit hierarchy you get warnings that the source cannot be found).