### PR TITLE
parse config and output dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +242,22 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "feature_gated"
@@ -468,6 +490,12 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
@@ -831,6 +859,7 @@ dependencies = [
  "pyo3-stub-gen-derive",
  "rust_decimal",
  "serde",
+ "tempfile",
  "test-case",
  "toml",
 ]
@@ -954,6 +983,19 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.1",
+]
 
 [[package]]
 name = "rustpython-ast"
@@ -1122,6 +1164,19 @@ name = "target-triple"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.1",
+]
 
 [[package]]
 name = "termcolor"

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -31,6 +31,7 @@ path = "../pyo3-stub-gen-derive"
 
 [dev-dependencies]
 test-case.workspace = true
+tempfile = "3.10"
 
 [features]
 default = ["numpy", "either", "infer_signature", "ordered-float"]

--- a/pyo3-stub-gen/src/pyproject.rs
+++ b/pyo3-stub-gen/src/pyproject.rs
@@ -60,6 +60,24 @@ impl PyProject {
         }
         None
     }
+
+    /// Return the output directory for stub files.
+    /// Uses `tool.pyo3-stub-gen.output-dir` if specified
+    pub fn output_dir(&self) -> Option<PathBuf> {
+        if let Some(tool) = &self.tool {
+            if let Some(config) = &tool.pyo3_stub_gen {
+                if let Some(output_dir) = &config.output_dir {
+                    return Some(
+                        self.toml_path
+                            .parent()
+                            .map(|base| base.join(output_dir))
+                            .unwrap_or_else(|| PathBuf::from(output_dir)),
+                    );
+                }
+            }
+        }
+        None
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -70,6 +88,8 @@ pub struct Project {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Tool {
     pub maturin: Option<Maturin>,
+    #[serde(rename = "pyo3-stub-gen")]
+    pub pyo3_stub_gen: Option<Pyo3StubGen>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -78,4 +98,179 @@ pub struct Maturin {
     pub python_source: Option<String>,
     #[serde(rename = "module-name")]
     pub module_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Pyo3StubGen {
+    #[serde(rename = "output-dir")]
+    pub output_dir: Option<String>,
+}
+
+#[test]
+fn test_pyo3_stub_gen_config() {
+    let toml_content = r#"
+[project]
+name = "test-package"
+
+[tool.pyo3-stub-gen]
+output-dir = "stubs"
+"#;
+
+    let pyproject: PyProject = toml::from_str(toml_content).unwrap();
+
+    assert_eq!(pyproject.project.name, "test-package");
+
+    let tool = pyproject.tool.as_ref().unwrap();
+    let pyo3_stub_gen = tool.pyo3_stub_gen.as_ref().unwrap();
+
+    assert_eq!(pyo3_stub_gen.output_dir.as_deref(), Some("stubs"));
+}
+
+#[test]
+fn test_pyo3_stub_gen_config_optional() {
+    let toml_content = r#"
+[project]
+name = "test-package"
+"#;
+
+    let pyproject: PyProject = toml::from_str(toml_content).unwrap();
+
+    assert_eq!(pyproject.project.name, "test-package");
+    assert!(pyproject.tool.is_none() || pyproject.tool.as_ref().unwrap().pyo3_stub_gen.is_none());
+}
+
+#[test]
+fn test_pyo3_stub_gen_with_maturin() {
+    let toml_content = r#"
+[project]
+name = "test-package"
+
+[tool.maturin]
+python-source = "python"
+module-name = "custom_module"
+
+[tool.pyo3-stub-gen]
+output-dir = "stubs"
+"#;
+
+    let pyproject: PyProject = toml::from_str(toml_content).unwrap();
+
+    assert_eq!(pyproject.project.name, "test-package");
+
+    let tool = pyproject.tool.as_ref().unwrap();
+
+    // Check maturin config
+    let maturin = tool.maturin.as_ref().unwrap();
+    assert_eq!(maturin.python_source.as_deref(), Some("python"));
+    assert_eq!(maturin.module_name.as_deref(), Some("custom_module"));
+
+    // Check pyo3-stub-gen config
+    let pyo3_stub_gen = tool.pyo3_stub_gen.as_ref().unwrap();
+    assert_eq!(pyo3_stub_gen.output_dir.as_deref(), Some("stubs"));
+}
+
+#[test]
+fn test_pyo3_stub_gen_output_dir_only() {
+    // Test with only output-dir specified
+    let toml_content = r#"
+[project]
+name = "test-package"
+
+[tool.pyo3-stub-gen]
+output-dir = "stubs"
+"#;
+
+    let pyproject: PyProject = toml::from_str(toml_content).unwrap();
+
+    let tool = pyproject.tool.as_ref().unwrap();
+    let pyo3_stub_gen = tool.pyo3_stub_gen.as_ref().unwrap();
+
+    assert_eq!(pyo3_stub_gen.output_dir.as_deref(), Some("stubs"));
+}
+
+#[test]
+fn test_output_dir_method_prioritizes_pyo3_stub_gen() {
+    use std::fs;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    // Create a temporary directory with a pyproject.toml
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pyproject.toml");
+
+    let toml_content = r#"
+[project]
+name = "test-package"
+
+[tool.maturin]
+python-source = "python"
+
+[tool.pyo3-stub-gen]
+output-dir = "stubs"
+"#;
+
+    let mut file = fs::File::create(&toml_path).unwrap();
+    file.write_all(toml_content.as_bytes()).unwrap();
+    drop(file);
+
+    let pyproject = PyProject::parse_toml(&toml_path).unwrap();
+
+    // output_dir() should return the pyo3-stub-gen output-dir
+    let output = pyproject.output_dir().unwrap();
+    assert_eq!(output, temp_dir.path().join("stubs"));
+}
+
+#[test]
+fn test_output_dir_method_returns_none() {
+    use std::fs;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    // Create a temporary directory with a pyproject.toml
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pyproject.toml");
+
+    let toml_content = r#"
+[project]
+name = "test-package"
+
+[tool.maturin]
+python-source = "python"
+"#;
+
+    let mut file = fs::File::create(&toml_path).unwrap();
+    file.write_all(toml_content.as_bytes()).unwrap();
+    drop(file);
+
+    let pyproject = PyProject::parse_toml(&toml_path).unwrap();
+
+    // output_dir() should be None
+
+    let output = pyproject.output_dir();
+    assert_eq!(output, None);
+}
+
+#[test]
+fn test_output_dir_method_returns_none_when_no_config() {
+    use std::fs;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    // Create a temporary directory with a minimal pyproject.toml
+    let temp_dir = TempDir::new().unwrap();
+    let toml_path = temp_dir.path().join("pyproject.toml");
+
+    let toml_content = r#"
+[project]
+name = "test-package"
+"#;
+
+    let mut file = fs::File::create(&toml_path).unwrap();
+    file.write_all(toml_content.as_bytes()).unwrap();
+    drop(file);
+
+    let pyproject = PyProject::parse_toml(&toml_path).unwrap();
+
+    // output_dir() should return None
+    assert!(pyproject.output_dir().is_none());
 }


### PR DESCRIPTION
As specified in the `architecture.md`, implement stub output dir configuration.