### PR TITLE
Support using raw literal keywords as types by stripping prefix during stubgen

### DIFF
--- a/pyo3-stub-gen-derive/src/gen_stub/member.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/member.rs
@@ -250,8 +250,14 @@ impl MemberInfo {
         let doc = extract_documents(&attrs).join("\n");
         let default = parse_gen_stub_default(&attrs)?;
         let deprecated = crate::gen_stub::attr::extract_deprecated(&attrs);
+        let base_name = field_name.unwrap_or_else(|| ident.unwrap().to_string());
+        let name = base_name
+            .strip_prefix("r#")
+            .unwrap_or(&base_name)
+            .to_string();
+
         Ok(Self {
-            name: field_name.unwrap_or(ident.unwrap().to_string()),
+            name: name,
             r#type: TypeOrOverride::RustType { r#type: ty },
             doc,
             default,

--- a/pyo3-stub-gen-derive/src/gen_stub/member.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/member.rs
@@ -257,7 +257,7 @@ impl MemberInfo {
             .to_string();
 
         Ok(Self {
-            name: name,
+            name,
             r#type: TypeOrOverride::RustType { r#type: ty },
             doc,
             default,

--- a/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
@@ -263,14 +263,14 @@ mod test {
             setters: &[
                 ::pyo3_stub_gen::type_info::MemberInfo {
                     name: "type",
-                    r#type: <String as ::pyo3_stub_gen::PyStubType>::type_output,
+                    r#type: <String as ::pyo3_stub_gen::PyStubType>::type_input,
                     doc: "",
                     default: None,
                     deprecated: None,
                 },
                 ::pyo3_stub_gen::type_info::MemberInfo {
                     name: "pub",
-                    r#type: <String as ::pyo3_stub_gen::PyStubType>::type_output,
+                    r#type: <String as ::pyo3_stub_gen::PyStubType>::type_input,
                     doc: "",
                     default: None,
                     deprecated: None,

--- a/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
@@ -210,6 +210,11 @@ mod test {
                 #[pyo3(get)]
                 pub description: Option<String>,
                 pub custom_latex: Option<String>,
+
+                #[pyo3(get,set)]
+                pub r#type: String,
+                #[pyo3(get,set)]
+                pub r#pub: String,
             }
             "#,
         )?;
@@ -240,8 +245,37 @@ mod test {
                     default: None,
                     deprecated: None,
                 },
+                ::pyo3_stub_gen::type_info::MemberInfo {
+                    name: "type",
+                    r#type: <String as ::pyo3_stub_gen::PyStubType>::type_output,
+                    doc: "",
+                    default: None,
+                    deprecated: None,
+                },
+                ::pyo3_stub_gen::type_info::MemberInfo {
+                    name: "pub",
+                    r#type: <String as ::pyo3_stub_gen::PyStubType>::type_output,
+                    doc: "",
+                    default: None,
+                    deprecated: None,
+                },
             ],
-            setters: &[],
+            setters: &[
+                ::pyo3_stub_gen::type_info::MemberInfo {
+                    name: "type",
+                    r#type: <String as ::pyo3_stub_gen::PyStubType>::type_output,
+                    doc: "",
+                    default: None,
+                    deprecated: None,
+                },
+                ::pyo3_stub_gen::type_info::MemberInfo {
+                    name: "pub",
+                    r#type: <String as ::pyo3_stub_gen::PyStubType>::type_output,
+                    doc: "",
+                    default: None,
+                    deprecated: None,
+                },
+            ],
             module: Some("my_module"),
             doc: "",
             bases: &[],


### PR DESCRIPTION
When structs have fields that are rust keywords (type, pub, etc) and specified using `r#` prefix. The prefix would leak into the stubs. This fixes it.