### PR TITLE
Implement `PyStubType` for `time` crate types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +673,12 @@ checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -780,6 +801,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "test-case",
+ "time",
  "toml",
 ]
 
@@ -1149,6 +1171,25 @@ dependencies = [
  "pyo3",
  "pyo3-stub-gen",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tiny-keccak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
   "examples/type-statement-alias",
   "examples/underscore_items",
   "pyo3-stub-gen",
-  "pyo3-stub-gen-derive"
+  "pyo3-stub-gen-derive",
 ]
 
 [workspace.package]
@@ -47,5 +47,6 @@ rust_decimal = { version = "1.40", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 syn = "2.0.114"
 test-case = "3.3.1"
+time = "0.3.47"
 toml = "0.9.11"
 trybuild = "1.0.114"

--- a/pyo3-stub-gen/Cargo.toml
+++ b/pyo3-stub-gen/Cargo.toml
@@ -23,6 +23,7 @@ ordered-float = { workspace = true, optional = true }
 pyo3.workspace = true
 rust_decimal = { workspace = true, optional = true }
 serde.workspace = true
+time.workspace = true
 toml.workspace = true
 
 [dependencies.pyo3-stub-gen-derive]

--- a/pyo3-stub-gen/src/stub_type/builtins.rs
+++ b/pyo3-stub-gen/src/stub_type/builtins.rs
@@ -10,8 +10,6 @@ use std::{
     time::SystemTime,
 };
 
-use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
-
 macro_rules! impl_builtin {
     ($ty:ty, $pytype:expr) => {
         impl PyStubType for $ty {
@@ -85,20 +83,27 @@ impl PyStubType for PathBuf {
     }
 }
 
-impl<Tz: TimeZone> PyStubType for DateTime<Tz> {
+impl<Tz: chrono::TimeZone> PyStubType for chrono::DateTime<Tz> {
     fn type_output() -> TypeInfo {
         TypeInfo::with_module("datetime.datetime", "datetime".into())
     }
 }
 
 impl_with_module!(SystemTime, "datetime.datetime", "datetime");
-impl_with_module!(NaiveDateTime, "datetime.datetime", "datetime");
-impl_with_module!(NaiveDate, "datetime.date", "datetime");
-impl_with_module!(NaiveTime, "datetime.time", "datetime");
-impl_with_module!(FixedOffset, "datetime.tzinfo", "datetime");
-impl_with_module!(Utc, "datetime.tzinfo", "datetime");
+impl_with_module!(chrono::NaiveDateTime, "datetime.datetime", "datetime");
+impl_with_module!(chrono::NaiveDate, "datetime.date", "datetime");
+impl_with_module!(chrono::NaiveTime, "datetime.time", "datetime");
+impl_with_module!(chrono::FixedOffset, "datetime.tzinfo", "datetime");
+impl_with_module!(chrono::Utc, "datetime.tzinfo", "datetime");
 impl_with_module!(std::time::Duration, "datetime.timedelta", "datetime");
 impl_with_module!(chrono::Duration, "datetime.timedelta", "datetime");
+impl_with_module!(time::Duration, "datetime.timedelta", "datetime");
+impl_with_module!(time::Date, "datetime.date", "datetime");
+impl_with_module!(time::OffsetDateTime, "datetime.datetime", "datetime");
+impl_with_module!(time::PrimitiveDateTime, "datetime.datetime", "datetime");
+impl_with_module!(time::UtcDateTime, "datetime.datetime", "datetime");
+impl_with_module!(time::Time, "datetime.time", "datetime");
+impl_with_module!(time::UtcOffset, "datetime.tzinfo", "datetime");
 
 impl<T: PyStubType> PyStubType for &T {
     fn type_input() -> TypeInfo {


### PR DESCRIPTION
This adds support for types from the [`time`](https://docs.rs/time/latest/time/index.html) crate, consistent with existing `chrono` support.