### PR TITLE
Fix setter stub to use type_input instead of type_output

### DIFF
--- a/examples/pure/docs/api/api_reference.json
+++ b/examples/pure/docs/api/api_reference.json
@@ -809,6 +809,65 @@
         },
         {
           "kind": "Class",
+          "name": "GetterSetterTypeTest",
+          "doc": "Test that setter stubs use `type_input` (e.g. `Sequence`) while getter stubs use `type_output` (e.g. `list`).\n\nFor `Vec<i32>`:\n- getter should produce `-> list[int]`\n- setter should produce `value: Sequence[int]`",
+          "bases": [],
+          "methods": [
+            {
+              "name": "__new__",
+              "doc": "",
+              "signatures": [
+                {
+                  "parameters": [
+                    {
+                      "name": "values",
+                      "type_": {
+                        "display": "Sequence[int]",
+                        "link_target": null,
+                        "children": [
+                          {
+                            "display": "int",
+                            "link_target": null,
+                            "children": []
+                          }
+                        ]
+                      },
+                      "default": null
+                    }
+                  ],
+                  "return_type": {
+                    "display": "GetterSetterTypeTest",
+                    "link_target": null,
+                    "children": []
+                  }
+                }
+              ],
+              "is_async": false,
+              "deprecated": null
+            }
+          ],
+          "attributes": [
+            {
+              "name": "values",
+              "doc": "",
+              "type_": {
+                "display": "list[int]",
+                "link_target": null,
+                "children": [
+                  {
+                    "display": "int",
+                    "link_target": null,
+                    "children": []
+                  }
+                ]
+              },
+              "is_property": true
+            }
+          ],
+          "deprecated": null
+        },
+        {
+          "kind": "Class",
           "name": "HashableStruct",
           "doc": "Test struct for hash and str methods",
           "bases": [],
@@ -4650,6 +4709,7 @@
     "pure.DocumentedUnion": "pure",
     "pure.FloatValues": "pure",
     "pure.GenericUnion": "pure",
+    "pure.GetterSetterTypeTest": "pure",
     "pure.HashableStruct": "pure",
     "pure.InstanceValue": "pure",
     "pure.MY_CONSTANT1": "pure",

--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -34,6 +34,7 @@ __all__ = [
     "DocumentedUnion",
     "FloatValues",
     "GenericUnion",
+    "GetterSetterTypeTest",
     "HashableStruct",
     "InstanceValue",
     "MY_CONSTANT1",
@@ -341,6 +342,21 @@ class FloatValues:
     Class attribute: regular float
     """
     def __new__(cls) -> FloatValues: ...
+
+@typing.final
+class GetterSetterTypeTest:
+    r"""
+    Test that setter stubs use `type_input` (e.g. `Sequence`) while getter stubs use `type_output` (e.g. `list`).
+    
+    For `Vec<i32>`:
+    - getter should produce `-> list[int]`
+    - setter should produce `value: Sequence[int]`
+    """
+    @property
+    def values(self) -> builtins.list[builtins.int]: ...
+    @values.setter
+    def values(self, value: typing.Sequence[builtins.int]) -> None: ...
+    def __new__(cls, values: typing.Sequence[builtins.int]) -> GetterSetterTypeTest: ...
 
 @typing.final
 class HashableStruct:

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -179,6 +179,36 @@ impl A {
     }
 }
 
+/// Test that setter stubs use `type_input` (e.g. `Sequence`) while getter stubs use `type_output` (e.g. `list`).
+///
+/// For `Vec<i32>`:
+/// - getter should produce `-> list[int]`
+/// - setter should produce `value: Sequence[int]`
+#[gen_stub_pyclass]
+#[pyclass]
+struct GetterSetterTypeTest {
+    values: Vec<i32>,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl GetterSetterTypeTest {
+    #[new]
+    fn new(values: Vec<i32>) -> Self {
+        Self { values }
+    }
+
+    #[getter]
+    fn values(&self) -> Vec<i32> {
+        self.values.clone()
+    }
+
+    #[setter]
+    fn set_values(&mut self, values: Vec<i32>) {
+        self.values = values;
+    }
+}
+
 #[gen_stub_pyfunction]
 #[pyfunction]
 #[pyo3(signature = (x = 2))]
@@ -470,6 +500,7 @@ fn pure(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<NormalClass>()?;
     m.add_class::<CustomEnum>()?;
     m.add_class::<CustomComplexEnum>()?;
+    m.add_class::<GetterSetterTypeTest>()?;
     m.add_function(wrap_pyfunction!(sum, m)?)?;
     m.add_function(wrap_pyfunction!(create_dict, m)?)?;
     m.add_function(wrap_pyfunction!(read_dict, m)?)?;

--- a/pyo3-stub-gen-derive/src/gen_stub/member.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/member.rs
@@ -18,11 +18,6 @@ pub enum MemberKind {
     Getter,
     /// Setter: uses `type_input` (the parameter type)
     Setter,
-    /// `#[pyo3(get, set)]` field: currently uses `type_output`.
-    /// Getter and setter metadata are constructed separately with their own `MemberKind`.
-    /// This variant is unused in the current implementation but kept for future use.
-    #[allow(dead_code)]
-    GetSet,
 }
 
 impl MemberKind {
@@ -355,7 +350,7 @@ impl ToTokens for MemberInfo {
                             {
                                 let mut type_name = #type_repr.to_string();
                                 #(
-                                    let type_info = <#marker_types as ::pyo3_stub_gen::PyStubType>::type_input();
+                                    let type_info = <#marker_types as ::pyo3_stub_gen::PyStubType>::#type_fn();
                                     type_name = type_name.replace(#rust_names, &type_info.name);
                                 )*
                                 type_name
@@ -365,7 +360,7 @@ impl ToTokens for MemberInfo {
                             {
                                 let mut type_refs = ::std::collections::HashMap::new();
                                 #(
-                                    let type_info = <#marker_types as ::pyo3_stub_gen::PyStubType>::type_input();
+                                    let type_info = <#marker_types as ::pyo3_stub_gen::PyStubType>::#type_fn();
                                     if let Some(module) = type_info.source_module {
                                         type_refs.insert(
                                             type_info.name.split('[').next().unwrap_or(&type_info.name).split('.').last().unwrap_or(&type_info.name).to_string(),

--- a/pyo3-stub-gen-derive/src/gen_stub/member.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/member.rs
@@ -18,8 +18,10 @@ pub enum MemberKind {
     Getter,
     /// Setter: uses `type_input` (the parameter type)
     Setter,
-    /// `#[pyo3(get, set)]` field: uses `type_output` for now
-    /// (one MemberInfo is shared by both getter and setter)
+    /// `#[pyo3(get, set)]` field: currently uses `type_output`.
+    /// Getter and setter metadata are constructed separately with their own `MemberKind`.
+    /// This variant is unused in the current implementation but kept for future use.
+    #[allow(dead_code)]
     GetSet,
 }
 
@@ -239,9 +241,8 @@ impl MemberInfo {
     }
 }
 
-impl TryFrom<Field> for MemberInfo {
-    type Error = Error;
-    fn try_from(field: Field) -> Result<Self> {
+impl MemberInfo {
+    pub fn from_field(field: Field, kind: MemberKind) -> Result<Self> {
         let Field {
             ident, ty, attrs, ..
         } = field;
@@ -260,7 +261,7 @@ impl TryFrom<Field> for MemberInfo {
             doc,
             default,
             deprecated,
-            kind: MemberKind::GetSet,
+            kind,
         })
     }
 }

--- a/pyo3-stub-gen-derive/src/gen_stub/member.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/member.rs
@@ -11,6 +11,24 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Attribute, Error, Expr, Field, FnArg, ImplItemConst, ImplItemFn, Result};
 
+/// Determines which `PyStubType` method to use when generating the type annotation.
+#[derive(Debug, Clone, Copy)]
+pub enum MemberKind {
+    /// Getter or classattr: uses `type_output` (the return type)
+    Getter,
+    /// Setter: uses `type_input` (the parameter type)
+    Setter,
+    /// `#[pyo3(get, set)]` field: uses `type_output` for now
+    /// (one MemberInfo is shared by both getter and setter)
+    GetSet,
+}
+
+impl MemberKind {
+    fn use_type_input(self) -> bool {
+        matches!(self, MemberKind::Setter)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MemberInfo {
     doc: String,
@@ -18,6 +36,7 @@ pub struct MemberInfo {
     r#type: TypeOrOverride,
     default: Option<Expr>,
     deprecated: Option<crate::gen_stub::attr::DeprecatedInfo>,
+    kind: MemberKind,
 }
 
 impl MemberInfo {
@@ -96,6 +115,7 @@ impl MemberInfo {
             r#type,
             default,
             deprecated: crate::gen_stub::attr::extract_deprecated(attrs),
+            kind: MemberKind::Getter,
         })
     }
     /// Create a new `MemberInfo` from a setter function.
@@ -169,6 +189,7 @@ impl MemberInfo {
             r#type,
             default,
             deprecated: crate::gen_stub::attr::extract_deprecated(attrs),
+            kind: MemberKind::Setter,
         })
     }
     pub fn new_classattr_fn(item: ImplItemFn) -> Result<Self> {
@@ -188,6 +209,7 @@ impl MemberInfo {
             r#type: extract_return_type(&sig.output, attrs)?.expect("Getter must return a type"),
             default,
             deprecated: crate::gen_stub::attr::extract_deprecated(attrs),
+            kind: MemberKind::Getter,
         })
     }
     pub fn new_classattr_const(item: ImplItemConst) -> Result<Self> {
@@ -212,6 +234,7 @@ impl MemberInfo {
             r#type: TypeOrOverride::RustType { r#type: ty },
             default: Some(expr),
             deprecated: crate::gen_stub::attr::extract_deprecated(&attrs),
+            kind: MemberKind::Getter,
         })
     }
 }
@@ -237,6 +260,7 @@ impl TryFrom<Field> for MemberInfo {
             doc,
             default,
             deprecated,
+            kind: MemberKind::GetSet,
         })
     }
 }
@@ -249,7 +273,9 @@ impl ToTokens for MemberInfo {
             doc,
             default,
             deprecated,
+            kind,
         } = self;
+        let use_type_input = kind.use_type_input();
         let default = default
             .as_ref()
             .map(|value| {
@@ -285,11 +311,16 @@ impl ToTokens for MemberInfo {
                 }
             })
             .unwrap_or_else(|| quote! { None });
+        let type_fn = if use_type_input {
+            quote! { type_input }
+        } else {
+            quote! { type_output }
+        };
         match r#type {
             TypeOrOverride::RustType { r#type: ty } => tokens.append_all(quote! {
                 ::pyo3_stub_gen::type_info::MemberInfo {
                     name: #name,
-                    r#type: <#ty as ::pyo3_stub_gen::PyStubType>::type_output,
+                    r#type: <#ty as ::pyo3_stub_gen::PyStubType>::#type_fn,
                     doc: #doc,
                     default: #default,
                     deprecated: #deprecated_info,

--- a/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
@@ -1,9 +1,6 @@
 use super::{
-    extract_documents,
-    member::MemberKind,
-    parse_pyo3_attrs,
-    util::quote_option,
-    Attr, MemberInfo, PyClassAttr, StubType,
+    extract_documents, member::MemberKind, parse_pyo3_attrs, util::quote_option, Attr, MemberInfo,
+    PyClassAttr, StubType,
 };
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};

--- a/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/pyclass.rs
@@ -1,6 +1,9 @@
 use super::{
-    extract_documents, parse_pyo3_attrs, util::quote_option, Attr, MemberInfo, PyClassAttr,
-    StubType,
+    extract_documents,
+    member::MemberKind,
+    parse_pyo3_attrs,
+    util::quote_option,
+    Attr, MemberInfo, PyClassAttr, StubType,
 };
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
@@ -108,11 +111,13 @@ impl PyClassInfo {
         let mut getters = Vec::new();
         let mut setters = Vec::new();
         for field in fields {
-            if is_get_all || MemberInfo::is_get(&field)? {
-                getters.push(MemberInfo::try_from(field.clone())?)
+            let has_get = is_get_all || MemberInfo::is_get(&field)?;
+            let has_set = is_set_all || MemberInfo::is_set(&field)?;
+            if has_get {
+                getters.push(MemberInfo::from_field(field.clone(), MemberKind::Getter)?)
             }
-            if is_set_all || MemberInfo::is_set(&field)? {
-                setters.push(MemberInfo::try_from(field)?)
+            if has_set {
+                setters.push(MemberInfo::from_field(field, MemberKind::Setter)?)
             }
         }
         let doc = extract_documents(&attrs).join("\n");

--- a/pyo3-stub-gen-derive/src/gen_stub/variant.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/variant.rs
@@ -1,6 +1,6 @@
 use crate::gen_stub::arg::ArgInfo;
 use crate::gen_stub::attr::{extract_documents, parse_pyo3_attrs, Attr};
-use crate::gen_stub::member::MemberInfo;
+use crate::gen_stub::member::{MemberInfo, MemberKind};
 use crate::gen_stub::parameter::Parameters;
 use crate::gen_stub::renaming::RenamingRule;
 use crate::gen_stub::signature::Signature;
@@ -75,7 +75,7 @@ impl VariantInfo {
             Fields::Unit => VariantForm::Unit,
             Fields::Named(fields) => {
                 for field in fields.named {
-                    members.push(MemberInfo::try_from(field)?)
+                    members.push(MemberInfo::from_field(field, MemberKind::Getter)?)
                 }
                 VariantForm::Struct
             }
@@ -83,7 +83,7 @@ impl VariantInfo {
                 for (i, field) in fields.unnamed.iter().enumerate() {
                     let mut named_field = field.clone();
                     named_field.ident = Some(Ident::new(&format!("_{i}"), field.ident.span()));
-                    members.push(MemberInfo::try_from(named_field)?)
+                    members.push(MemberInfo::from_field(named_field, MemberKind::Getter)?)
                 }
                 VariantForm::Tuple
             }

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -134,7 +134,7 @@ pub struct MethodInfo {
     pub is_overload: bool,
 }
 
-/// Info of getter method decorated with `#[getter]` or `#[pyo3(get, set)]` appears in `#[pyclass]`
+/// Info of getter/setter method decorated with `#[getter]`/`#[setter]` or `#[pyo3(get, set)]` appears in `#[pyclass]`
 #[derive(Debug)]
 pub struct MemberInfo {
     pub name: &'static str,


### PR DESCRIPTION
## Summary

- Setter parameters now correctly use `PyStubType::type_input` instead of `type_output` for stub generation
- Introduces `MemberKind` enum (`Getter`, `Setter`) to track the role at compile time
- For `#[pyo3(get, set)]` fields, getter and setter `MemberInfo` are constructed separately with their respective kind
- `OverrideType` branch also respects `MemberKind` for `rust_type_markers` resolution

## Problem

When a type implements `PyStubType` with different `type_input()` and `type_output()` (e.g. `Function` → `ToFunction` for input, `Function` for output), setter stubs were incorrectly generated:

```python
# Before (wrong)
@objective.setter
def objective(self, value: Function) -> None: ...

# After (correct)
@objective.setter
def objective(self, value: ToFunction) -> None: ...
```

## Test plan

- [x] `cargo check` passes for all workspace members
- [x] `cargo test` passes
- [x] Added `GetterSetterTypeTest` example in pure: verifies `Vec<i32>` getter → `list[int]`, setter → `Sequence[int]`
- [x] Verified correct stub output in downstream project (ommx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)