### PR TITLE
Add generate-index option to doc-gen config

### DIFF
--- a/examples/generate_init_py/docs/api/api_reference.json
+++ b/examples/generate_init_py/docs/api/api_reference.json
@@ -317,6 +317,7 @@
     "intro-message": "Example for generate-init-py feature.",
     "index-title": null,
     "contents-table": true,
-    "separate-items": false
+    "separate-items": false,
+    "generate-index": true
   }
 }

--- a/examples/mixed/docs/api/api_reference.json
+++ b/examples/mixed/docs/api/api_reference.json
@@ -952,6 +952,7 @@
     "intro-message": "Custom documentation for the mixed example project demonstrating PyO3 stub generation.",
     "index-title": "Mixed Example API Documentation",
     "contents-table": false,
-    "separate-items": false
+    "separate-items": false,
+    "generate-index": true
   }
 }

--- a/examples/pure/docs/api/api_reference.json
+++ b/examples/pure/docs/api/api_reference.json
@@ -4808,6 +4808,7 @@
     "intro-message": null,
     "index-title": "API Reference",
     "contents-table": true,
-    "separate-items": true
+    "separate-items": true,
+    "generate-index": true
   }
 }

--- a/examples/underscore_items/docs/api/api_reference.json
+++ b/examples/underscore_items/docs/api/api_reference.json
@@ -74,6 +74,7 @@
     "intro-message": null,
     "index-title": null,
     "contents-table": false,
-    "separate-items": false
+    "separate-items": false,
+    "generate-index": true
   }
 }

--- a/pyo3-stub-gen/src/docgen/config.rs
+++ b/pyo3-stub-gen/src/docgen/config.rs
@@ -35,6 +35,11 @@ pub struct DocGenConfig {
     /// When true, module pages show a summary table with links to individual item pages.
     #[serde(rename = "separate-items", default)]
     pub separate_items: bool,
+
+    /// Generate index.rst file (default: true)
+    /// Set to false to skip generating index.rst, useful when a hand-maintained index.rst exists.
+    #[serde(rename = "generate-index", default = "default_generate_index")]
+    pub generate_index: bool,
 }
 
 impl Default for DocGenConfig {
@@ -47,6 +52,7 @@ impl Default for DocGenConfig {
             index_title: None,
             contents_table: false,
             separate_items: false,
+            generate_index: default_generate_index(),
         }
     }
 }
@@ -60,6 +66,10 @@ fn default_json_output() -> String {
 }
 
 fn default_separate_pages() -> bool {
+    true
+}
+
+fn default_generate_index() -> bool {
     true
 }
 

--- a/pyo3-stub-gen/src/generate/stub_info.rs
+++ b/pyo3-stub-gen/src/generate/stub_info.rs
@@ -210,7 +210,13 @@ impl StubInfo {
         // 5. Generate RST files
         if config.separate_pages {
             crate::docgen::render::generate_module_pages(&doc_package, &config.output_dir, config)?;
-            crate::docgen::render::generate_index_rst(&doc_package, &config.output_dir, config)?;
+            if config.generate_index {
+                crate::docgen::render::generate_index_rst(
+                    &doc_package,
+                    &config.output_dir,
+                    config,
+                )?;
+            }
             if config.separate_items {
                 crate::docgen::render::generate_item_pages(&doc_package, &config.output_dir)?;
                 log::info!("Generated separate .rst pages for each item");


### PR DESCRIPTION
## Summary
- Add `generate-index` option to `[tool.pyo3-stub-gen.doc-gen]` config (default: `true`)
- When set to `false`, skips `index.rst` generation while still producing module pages, item pages, and JSON output
- Useful when a project maintains a hand-written `index.rst` with additional toctree entries (e.g. autoapi sections)

## Motivation
In Jij-Inc/ommx#785, the docs were migrated from Jupyter Book to Sphinx. The `docs/api/index.rst` now contains hand-maintained entries for autoapi-generated adapter docs. The pyo3-stub-gen docgen would overwrite this file, so we need a way to skip its generation.

## Test plan
- [x] `cargo check` passes
- [ ] Verify that `generate-index = false` in pyproject.toml skips index.rst generation
- [ ] Verify that default behavior (no config / `generate-index = true`) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)