### PR TITLE
allow runtime CARGO_MANIFEST_DIR env var override build time env var

### DIFF
--- a/pyo3-stub-gen/src/generate/stub_info.rs
+++ b/pyo3-stub-gen/src/generate/stub_info.rs
@@ -241,9 +241,9 @@ struct StubInfoBuilder {
 impl StubInfoBuilder {
     fn from_pyproject_toml(pyproject: PyProject, config: StubGenConfig) -> Self {
         let is_mixed_layout = pyproject.python_source().is_some();
-        let python_root = pyproject
-            .python_source()
-            .unwrap_or(PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()));
+        let python_root = pyproject.python_source().unwrap_or(PathBuf::from(
+            std::env::var("CARGO_MANIFEST_DIR").unwrap_or(env!("CARGO_MANIFEST_DIR").to_string()),
+        ));
 
         Self {
             modules: BTreeMap::new(),

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -207,7 +207,9 @@ macro_rules! define_stub_info_gatherer {
     ($function_name:ident) => {
         /// Auto-generated function to gather information to generate stub files
         pub fn $function_name() -> $crate::Result<$crate::StubInfo> {
-            let manifest_dir: &::std::path::Path = env!("CARGO_MANIFEST_DIR").as_ref();
+            let manifest_dir: ::std::path::PathBuf = std::env::var("CARGO_MANIFEST_DIR")
+                .unwrap_or(env!("CARGO_MANIFEST_DIR").to_string())
+                .into();
             $crate::StubInfo::from_pyproject_toml(manifest_dir.join("pyproject.toml"))
         }
     };


### PR DESCRIPTION
this PR allow runtime CARGO_MANIFEST_DIR env var to override compile time value. for the following reasons:

1. define_stub_info_gatherer! macro use compile time env var, while StubInfoBuilder attempts to unwrap the runtime variable,   when binary executed standalone (not launch by cargo), this inconsistency can confuse users and may even cause a crash due to the unwrap
2. in restricted build environment (e.g. bazel sandbox), binary is built in one sandbox environment but executed in another , the compile time CARGO_MANIFEST_DIR can't be read in such case, this changes allow binary being executed with runtime specified pyproject, regardless of the build directory

