### PR TITLE
Add module_typevar! macro for TypeVar declarations

### DIFF
--- a/examples/pure/.stubtest-allowlist
+++ b/examples/pure/.stubtest-allowlist
@@ -22,3 +22,10 @@ pure.StrIntMap
 pure.StructUnion
 pure.TripleUnion
 pure.UndocumentedCallback
+# TypeVars
+pure.BOUNDED
+pure.CONTRAVARIANT_T
+pure.COVARIANT_T
+pure.STR_OR_INT
+pure.T
+pure.U

--- a/examples/pure/pure.pyi
+++ b/examples/pure/pure.pyi
@@ -187,6 +187,12 @@ StrIntMap: TypeAlias = builtins.dict[builtins.str, builtins.int]
 StructUnion: TypeAlias = ComparableStruct  |  HashableStruct
 TripleUnion: TypeAlias = builtins.int | builtins.str | builtins.bool
 UndocumentedCallback: TypeAlias = collections.abc.Callable[[int], bool]
+BOUNDED = typing.TypeVar("BOUNDED", bound=str)
+CONTRAVARIANT_T = typing.TypeVar("CONTRAVARIANT_T", contravariant=True)
+COVARIANT_T = typing.TypeVar("COVARIANT_T", covariant=True)
+STR_OR_INT = typing.TypeVar("STR_OR_INT", str, int)
+T = typing.TypeVar("T")
+U = typing.TypeVar("U")
 MY_CONSTANT1: builtins.int
 MY_CONSTANT2: builtins.int = 123
 class A:

--- a/examples/pure/src/lib.rs
+++ b/examples/pure/src/lib.rs
@@ -30,7 +30,7 @@ mod readme {}
 use ahash::RandomState;
 use pyo3::{prelude::*, types::*};
 use pyo3_stub_gen::{
-    define_stub_info_gatherer, derive::*, module_doc, module_variable,
+    define_stub_info_gatherer, derive::*, module_doc, module_typevar, module_variable,
     runtime::PyModuleTypeAliasExt, type_alias,
 };
 use rust_decimal::Decimal;
@@ -431,6 +431,14 @@ impl DecimalHolder {
 
 module_variable!("pure", "MY_CONSTANT1", usize);
 module_variable!("pure", "MY_CONSTANT2", usize, 123);
+
+// Test module-level TypeVar
+module_typevar!("pure", "T");
+module_typevar!("pure", "U");
+module_typevar!("pure", "STR_OR_INT", constraints = &["str", "int"]);
+module_typevar!("pure", "BOUNDED", bound = "str");
+module_typevar!("pure", "COVARIANT_T", covariant = true);
+module_typevar!("pure", "CONTRAVARIANT_T", contravariant = true);
 
 #[gen_stub_pyfunction]
 #[pyfunction]

--- a/pyo3-stub-gen/src/generate/module.rs
+++ b/pyo3-stub-gen/src/generate/module.rs
@@ -27,6 +27,7 @@ pub struct Module {
     pub function: BTreeMap<&'static str, Vec<FunctionDef>>,
     pub variables: BTreeMap<&'static str, VariableDef>,
     pub type_aliases: BTreeMap<&'static str, TypeAliasDef>,
+    pub type_vars: BTreeMap<&'static str, TypeVarDef>,
     pub name: String,
     pub default_module_name: String,
     /// Direct submodules of this module.
@@ -52,6 +53,7 @@ impl Module {
             && self.function.is_empty()
             && self.variables.is_empty()
             && self.type_aliases.is_empty()
+            && self.type_vars.is_empty()
             && self.submodules.is_empty()
             && self.module_re_exports.is_empty()
             && self.verbatim_all_entries.is_empty()
@@ -68,6 +70,7 @@ impl Module {
             && self.function.is_empty()
             && self.variables.is_empty()
             && self.type_aliases.is_empty()
+            && self.type_vars.is_empty()
     }
 
     /// Get the names of all declared items in this module.
@@ -138,7 +141,7 @@ impl Module {
                     let has_overload = functions.iter().any(|func| func.is_overload);
                     functions.len() > 1 && has_overload
                 });
-                if any_overloaded {
+                if any_overloaded || !self.module.type_vars.is_empty() {
                     imports.insert("typing".into());
                 }
 
@@ -228,6 +231,11 @@ impl Module {
                 for alias in self.module.type_aliases.values() {
                     alias.fmt_with_config(&self.module.name, f, self.use_type_statement)?;
                     writeln!(f)?;
+                }
+
+                // Generate type vars
+                for type_var in self.module.type_vars.values() {
+                    writeln!(f, "{type_var}")?;
                 }
 
                 // Generate variables
@@ -450,7 +458,7 @@ impl fmt::Display for Module {
             let has_overload = functions.iter().any(|f| f.is_overload);
             functions.len() > 1 && has_overload
         });
-        if any_overloaded {
+        if any_overloaded || !self.type_vars.is_empty() {
             imports.insert("typing".into());
         }
 
@@ -537,6 +545,9 @@ impl fmt::Display for Module {
         for alias in self.type_aliases.values() {
             alias.fmt_for_module(&self.name, f)?;
             writeln!(f)?;
+        }
+        for type_var in self.type_vars.values() {
+            writeln!(f, "{type_var}")?;
         }
         for var in self.variables.values() {
             var.fmt_for_module(&self.name, f)?;

--- a/pyo3-stub-gen/src/generate/stub_info.rs
+++ b/pyo3-stub-gen/src/generate/stub_info.rs
@@ -401,6 +401,12 @@ impl StubInfoBuilder {
             .insert(info.name, VariableDef::from(info));
     }
 
+    fn add_type_var(&mut self, info: &PyTypeVarInfo) {
+        self.get_module(Some(info.module))
+            .type_vars
+            .insert(info.name, TypeVarDef::from(info));
+    }
+
     fn add_type_alias(&mut self, info: &TypeAliasInfo) {
         self.get_module(Some(info.module))
             .type_aliases
@@ -648,6 +654,9 @@ impl StubInfoBuilder {
         }
         for info in inventory::iter::<PyVariableInfo> {
             self.add_variable(info);
+        }
+        for info in inventory::iter::<PyTypeVarInfo> {
+            self.add_type_var(info);
         }
         for info in inventory::iter::<TypeAliasInfo> {
             self.add_type_alias(info);

--- a/pyo3-stub-gen/src/generate/variable.rs
+++ b/pyo3-stub-gen/src/generate/variable.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashSet, fmt};
 
-use crate::{generate::Import, stub_type::ImportRef, type_info::PyVariableInfo, TypeInfo};
+use crate::{
+    generate::Import, stub_type::ImportRef, type_info::PyTypeVarInfo, type_info::PyVariableInfo,
+    TypeInfo,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct VariableDef {
@@ -47,5 +50,160 @@ impl VariableDef {
             write!(f, " = {default}")?;
         }
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeVarDef {
+    pub name: &'static str,
+    pub constraints: Vec<String>,
+    pub bound: Option<String>,
+    pub covariant: bool,
+    pub contravariant: bool,
+}
+
+impl From<&PyTypeVarInfo> for TypeVarDef {
+    fn from(info: &PyTypeVarInfo) -> Self {
+        Self {
+            name: info.name,
+            constraints: info.constraints.iter().map(|s| s.to_string()).collect(),
+            bound: info.bound.map(|s| s.to_string()),
+            covariant: info.covariant,
+            contravariant: info.contravariant,
+        }
+    }
+}
+
+impl fmt::Display for TypeVarDef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} = typing.TypeVar(\"{}\"", self.name, self.name)?;
+
+        // Add constraints as positional arguments
+        for constraint in &self.constraints {
+            write!(f, ", {}", constraint)?;
+        }
+
+        // Add keyword arguments
+        if let Some(bound) = &self.bound {
+            write!(f, ", bound={}", bound)?;
+        }
+        if self.covariant {
+            write!(f, ", covariant=True")?;
+        }
+        if self.contravariant {
+            write!(f, ", contravariant=True")?;
+        }
+
+        write!(f, ")")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_typevar_def_display_basic() {
+        let typevar = TypeVarDef {
+            name: "T",
+            constraints: vec![],
+            bound: None,
+            covariant: false,
+            contravariant: false,
+        };
+        assert_eq!(typevar.to_string(), "T = typing.TypeVar(\"T\")");
+    }
+
+    #[test]
+    fn test_typevar_def_with_constraints() {
+        let typevar = TypeVarDef {
+            name: "T",
+            constraints: vec!["str".to_string(), "int".to_string()],
+            bound: None,
+            covariant: false,
+            contravariant: false,
+        };
+        assert_eq!(
+            typevar.to_string(),
+            "T = typing.TypeVar(\"T\", str, int)"
+        );
+    }
+
+    #[test]
+    fn test_typevar_def_with_bound() {
+        let typevar = TypeVarDef {
+            name: "T",
+            constraints: vec![],
+            bound: Some("BaseClass".to_string()),
+            covariant: false,
+            contravariant: false,
+        };
+        assert_eq!(
+            typevar.to_string(),
+            "T = typing.TypeVar(\"T\", bound=BaseClass)"
+        );
+    }
+
+    #[test]
+    fn test_typevar_def_covariant() {
+        let typevar = TypeVarDef {
+            name: "T",
+            constraints: vec![],
+            bound: None,
+            covariant: true,
+            contravariant: false,
+        };
+        assert_eq!(
+            typevar.to_string(),
+            "T = typing.TypeVar(\"T\", covariant=True)"
+        );
+    }
+
+    #[test]
+    fn test_typevar_def_contravariant() {
+        let typevar = TypeVarDef {
+            name: "T",
+            constraints: vec![],
+            bound: None,
+            covariant: false,
+            contravariant: true,
+        };
+        assert_eq!(
+            typevar.to_string(),
+            "T = typing.TypeVar(\"T\", contravariant=True)"
+        );
+    }
+
+    #[test]
+    fn test_typevar_def_all_parameters() {
+        let typevar = TypeVarDef {
+            name: "T",
+            constraints: vec!["str".to_string(), "int".to_string()],
+            bound: None,
+            covariant: true,
+            contravariant: false,
+        };
+        assert_eq!(
+            typevar.to_string(),
+            "T = typing.TypeVar(\"T\", str, int, covariant=True)"
+        );
+    }
+
+    #[test]
+    fn test_typevar_def_from_py_typevar_info() {
+        let info = PyTypeVarInfo {
+            name: "U",
+            module: "test_module",
+            constraints: &["str", "int"],
+            bound: Some("BaseClass"),
+            covariant: true,
+            contravariant: false,
+        };
+        let typevar = TypeVarDef::from(&info);
+        assert_eq!(typevar.name, "U");
+        assert_eq!(
+            typevar.to_string(),
+            "U = typing.TypeVar(\"U\", str, int, bound=BaseClass, covariant=True)"
+        );
     }
 }

--- a/pyo3-stub-gen/src/generate/variable.rs
+++ b/pyo3-stub-gen/src/generate/variable.rs
@@ -123,10 +123,7 @@ mod tests {
             covariant: false,
             contravariant: false,
         };
-        assert_eq!(
-            typevar.to_string(),
-            "T = typing.TypeVar(\"T\", str, int)"
-        );
+        assert_eq!(typevar.to_string(), "T = typing.TypeVar(\"T\", str, int)");
     }
 
     #[test]

--- a/pyo3-stub-gen/src/lib.rs
+++ b/pyo3-stub-gen/src/lib.rs
@@ -278,6 +278,180 @@ macro_rules! module_variable {
     };
 }
 
+/// Declare a module-level `typing.TypeVar`. Renders as `name = typing.TypeVar("name", ...)`
+/// (bare assignment, no annotation), which is what type checkers require for the name
+/// to be usable inside type expressions.
+///
+/// # Basic usage
+/// ```rust
+/// pyo3_stub_gen::module_typevar!("my_module", "T");
+/// ```
+///
+/// # With constraints
+/// ```rust
+/// pyo3_stub_gen::module_typevar!("my_module", "T", constraints = &["str", "int"]);
+/// ```
+///
+/// # With bound
+/// ```rust
+/// pyo3_stub_gen::module_typevar!("my_module", "T", bound = "BaseClass");
+/// ```
+///
+/// # Covariant or contravariant
+/// ```rust
+/// pyo3_stub_gen::module_typevar!("my_module", "T", covariant = true);
+/// pyo3_stub_gen::module_typevar!("my_module", "T", contravariant = true);
+/// ```
+///
+/// # Combined parameters
+/// ```rust
+/// pyo3_stub_gen::module_typevar!(
+///     "my_module",
+///     "T",
+///     constraints = &["str", "int"],
+///     covariant = true
+/// );
+/// ```
+#[macro_export]
+macro_rules! module_typevar {
+    // Basic form
+    ($module:expr, $name:expr) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: &[],
+                bound: None,
+                covariant: false,
+                contravariant: false,
+            }
+        }
+    };
+    // Single parameter forms
+    ($module:expr, $name:expr, constraints = $constraints:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: $constraints,
+                bound: None,
+                covariant: false,
+                contravariant: false,
+            }
+        }
+    };
+    ($module:expr, $name:expr, bound = $bound:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: &[],
+                bound: Some($bound),
+                covariant: false,
+                contravariant: false,
+            }
+        }
+    };
+    ($module:expr, $name:expr, covariant = $covariant:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: &[],
+                bound: None,
+                covariant: $covariant,
+                contravariant: false,
+            }
+        }
+    };
+    ($module:expr, $name:expr, contravariant = $contravariant:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: &[],
+                bound: None,
+                covariant: false,
+                contravariant: $contravariant,
+            }
+        }
+    };
+    // Two parameter forms
+    ($module:expr, $name:expr, constraints = $constraints:expr, bound = $bound:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: $constraints,
+                bound: Some($bound),
+                covariant: false,
+                contravariant: false,
+            }
+        }
+    };
+    ($module:expr, $name:expr, constraints = $constraints:expr, covariant = $covariant:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: $constraints,
+                bound: None,
+                covariant: $covariant,
+                contravariant: false,
+            }
+        }
+    };
+    ($module:expr, $name:expr, constraints = $constraints:expr, contravariant = $contravariant:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: $constraints,
+                bound: None,
+                covariant: false,
+                contravariant: $contravariant,
+            }
+        }
+    };
+    ($module:expr, $name:expr, bound = $bound:expr, covariant = $covariant:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: &[],
+                bound: Some($bound),
+                covariant: $covariant,
+                contravariant: false,
+            }
+        }
+    };
+    ($module:expr, $name:expr, bound = $bound:expr, contravariant = $contravariant:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: &[],
+                bound: Some($bound),
+                covariant: false,
+                contravariant: $contravariant,
+            }
+        }
+    };
+    // All parameters
+    ($module:expr, $name:expr, constraints = $constraints:expr, bound = $bound:expr, covariant = $covariant:expr, contravariant = $contravariant:expr $(,)?) => {
+        $crate::inventory::submit! {
+            $crate::type_info::PyTypeVarInfo {
+                name: $name,
+                module: $module,
+                constraints: $constraints,
+                bound: Some($bound),
+                covariant: $covariant,
+                contravariant: $contravariant,
+            }
+        }
+    };
+}
+
 /// Define a module-level type alias with runtime support.
 ///
 /// This macro creates a zero-sized struct that:

--- a/pyo3-stub-gen/src/type_info.rs
+++ b/pyo3-stub-gen/src/type_info.rs
@@ -282,6 +282,18 @@ pub struct PyVariableInfo {
 inventory::collect!(PyVariableInfo);
 
 #[derive(Debug)]
+pub struct PyTypeVarInfo {
+    pub name: &'static str,
+    pub module: &'static str,
+    pub constraints: &'static [&'static str],
+    pub bound: Option<&'static str>,
+    pub covariant: bool,
+    pub contravariant: bool,
+}
+
+inventory::collect!(PyTypeVarInfo);
+
+#[derive(Debug)]
 pub struct TypeAliasInfo {
     pub name: &'static str,
     pub module: &'static str,


### PR DESCRIPTION
Generates bare TypeVar assignments with support for constraints, bound, covariant, and contravariant parameters.

This is a potential solution to: https://github.com/Jij-Inc/pyo3-stub-gen/issues/382