### PR TITLE
Allow pyclass name to be provided by a macro argument

### DIFF
--- a/pyo3-stub-gen-derive/src/gen_stub/attr.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/attr.rs
@@ -252,6 +252,9 @@ pub fn parse_pyo3_attr(attr: &Attribute) -> Result<Vec<Attr>> {
                         } else if ident == "constructor" {
                             pyo3_attrs
                                 .push(Attr::Constructor(syn::parse2(group.to_token_stream())?));
+                        } else if ident == "name" {
+                            let literal = syn::parse2::<syn::LitStr>(group.to_token_stream())?;
+                            pyo3_attrs.push(Attr::Name(literal.value()));
                         }
                     }
                     [Ident(ident), Punct(_), Ident(ident2)] => {


### PR DESCRIPTION
Motivating example:

```
macro_rules! generate_example {
    ($name:literal) => {
        #[pyo3_stub_gen::derive::gen_stub_pyclass]
        #[pyo3::pyclass(name = $name)]
        struct Example {}
    };
}

generate_example!("ExampleNameOverride");
```

The name attribute silently fails to parse in this scenario since the argument is received as a group rather than a literal:

```
[
    Ident {
        sym: name,
        span: <omitted>,
    },
    Punct {
        char: '=',
        spacing: Alone,
        span: <omitted>,
    },
    Group {
        delimiter: None,
        stream: TokenStream [
            Literal {
                kind: Str,
                symbol: "ExampleNameOverride",
                suffix: None,
                span: <omitted>,
            },
        ],
        span: <omitted>,
    },
]
```