### PR TITLE
fix(derive): accept name/module/rename_all from macro_rules! substitution

### DIFF
--- a/pyo3-stub-gen-derive/src/gen_stub/attr.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/attr.rs
@@ -252,6 +252,9 @@ pub fn parse_pyo3_attr(attr: &Attribute) -> Result<Vec<Attr>> {
                         } else if ident == "constructor" {
                             pyo3_attrs
                                 .push(Attr::Constructor(syn::parse2(group.to_token_stream())?));
+                        } else if ident == "name" {
+                            let literal = syn::parse2::<syn::LitStr>(group.to_token_stream())?;
+                            pyo3_attrs.push(Attr::Name(literal.value()));
                         }
                     }
                     [Ident(ident), Punct(_), Ident(ident2)] => {

--- a/pyo3-stub-gen-derive/src/gen_stub/attr.rs
+++ b/pyo3-stub-gen-derive/src/gen_stub/attr.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexSet;
 
 use super::{RenamingRule, Signature};
-use proc_macro2::{TokenStream as TokenStream2, TokenTree};
+use proc_macro2::{Delimiter, TokenStream as TokenStream2, TokenTree};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
     parenthesized,
@@ -189,7 +189,12 @@ pub fn parse_pyo3_attr(attr: &Attribute) -> Result<Vec<Attr>> {
         // https://pyo3.rs/v0.19.1/function/signature
         if let Meta::List(MetaList { tokens, .. }) = &attr.meta {
             use TokenTree::*;
-            let tokens: Vec<TokenTree> = tokens.clone().into_iter().collect();
+            // `macro_rules!` substitutions (e.g. `#[pyclass(name = $name)]` where
+            // `$name:literal`) wrap the inserted token in an "invisible group"
+            // (`Group { delimiter: None, .. }`). Flattening these first lets a
+            // single pattern arm handle both direct literals and macro-substituted
+            // values uniformly.
+            let tokens: Vec<TokenTree> = flatten_invisible_groups(tokens.clone()).collect();
             // Since `(...)` part with `signature` becomes `TokenTree::Group`,
             // we can split entire stream by `,` first, and then pattern match to each cases.
             for tt in tokens.split(|tt| {
@@ -252,9 +257,6 @@ pub fn parse_pyo3_attr(attr: &Attribute) -> Result<Vec<Attr>> {
                         } else if ident == "constructor" {
                             pyo3_attrs
                                 .push(Attr::Constructor(syn::parse2(group.to_token_stream())?));
-                        } else if ident == "name" {
-                            let literal = syn::parse2::<syn::LitStr>(group.to_token_stream())?;
-                            pyo3_attrs.push(Attr::Name(literal.value()));
                         }
                     }
                     [Ident(ident), Punct(_), Ident(ident2)] => {
@@ -291,6 +293,22 @@ pub fn parse_pyo3_attr(attr: &Attribute) -> Result<Vec<Attr>> {
     Ok(pyo3_attrs)
 }
 
+/// Flatten `Group { delimiter: None, .. }` tokens (produced by `macro_rules!`
+/// substitutions) into their contents so downstream pattern matching can treat
+/// macro-substituted values the same as written-out literals.
+fn flatten_invisible_groups(tokens: TokenStream2) -> impl Iterator<Item = TokenTree> {
+    tokens
+        .into_iter()
+        .flat_map(|tt| -> Box<dyn Iterator<Item = TokenTree>> {
+            match tt {
+                TokenTree::Group(g) if g.delimiter() == Delimiter::None => {
+                    Box::new(flatten_invisible_groups(g.stream()))
+                }
+                other => Box::new(std::iter::once(other)),
+            }
+        })
+}
+
 /// Parse standalone `#[gen_stub(module = "...")]` attribute for module override
 pub fn parse_gen_stub_module_attr(attr: &Attribute) -> Result<Option<Attr>> {
     let path = attr.path();
@@ -298,7 +316,8 @@ pub fn parse_gen_stub_module_attr(attr: &Attribute) -> Result<Option<Attr>> {
         // Parse the inner tokens to find module = "..."
         if let Meta::List(MetaList { tokens, .. }) = &attr.meta {
             use TokenTree::*;
-            let tokens: Vec<TokenTree> = tokens.clone().into_iter().collect();
+            // See note in `parse_pyo3_attr` about invisible groups.
+            let tokens: Vec<TokenTree> = flatten_invisible_groups(tokens.clone()).collect();
 
             // Split by comma and look for module = "..."
             for tt in tokens.split(|tt| {
@@ -699,6 +718,70 @@ mod test {
         }
         Ok(())
     }
+    /// Build a `Vec<Attribute>` whose tokens contain an "invisible group"
+    /// (`Group { delimiter: None, .. }`) for the value of a key, simulating
+    /// what `macro_rules!` produces when substituting a meta-variable into an
+    /// attribute argument list (e.g. `#[pyclass(name = $name)]`).
+    fn attrs_with_invisible_group(
+        attr_path: TokenStream2,
+        prefix: TokenStream2,
+        value: TokenStream2,
+    ) -> Vec<Attribute> {
+        let invisible = TokenTree::Group(proc_macro2::Group::new(Delimiter::None, value));
+        let item: ItemStruct = syn::parse2(quote! {
+            #[#attr_path(#prefix = #invisible)]
+            struct Dummy;
+        })
+        .unwrap();
+        item.attrs
+    }
+
+    #[test]
+    fn test_parse_pyo3_attr_name_from_macro_substitution() -> Result<()> {
+        // Simulates `macro_rules! { ($n:literal) => { #[pyclass(name = $n)] ... } }`.
+        let attrs = attrs_with_invisible_group(quote!(pyclass), quote!(name), quote!("FromMacro"));
+        let parsed = parse_pyo3_attrs(&attrs)?;
+        assert_eq!(parsed, vec![Attr::Name("FromMacro".to_string())]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_pyo3_attr_module_from_macro_substitution() -> Result<()> {
+        let attrs =
+            attrs_with_invisible_group(quote!(pyclass), quote!(module), quote!("my.mod.path"));
+        let parsed = parse_pyo3_attrs(&attrs)?;
+        assert_eq!(parsed, vec![Attr::Module("my.mod.path".to_string())]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_pyo3_attr_rename_all_from_macro_substitution() -> Result<()> {
+        let attrs = attrs_with_invisible_group(
+            quote!(pyo3),
+            quote!(rename_all),
+            quote!("SCREAMING_SNAKE_CASE"),
+        );
+        let parsed = parse_pyo3_attrs(&attrs)?;
+        assert_eq!(
+            parsed,
+            vec![Attr::RenameAll(RenamingRule::ScreamingSnakeCase)]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_gen_stub_module_attr_from_macro_substitution() -> Result<()> {
+        let attrs =
+            attrs_with_invisible_group(quote!(gen_stub), quote!(module), quote!("explicit.mod"));
+        // `parse_pyo3_attrs` also dispatches to `parse_gen_stub_module_attr`.
+        let parsed = parse_pyo3_attrs(&attrs)?;
+        assert_eq!(
+            parsed,
+            vec![Attr::GenStubModule("explicit.mod".to_string())]
+        );
+        Ok(())
+    }
+
     #[test]
     fn test_parse_gen_stub_field_attr() -> Result<()> {
         let item: ItemStruct = parse_str(


### PR DESCRIPTION
Builds on #465 (the underlying `name = $name` fix, cherry-picked here and credited to @alteous) and extends the same treatment to the rest of the affected attributes.

## Problem

`macro_rules!` substitutions wrap the inserted token in an "invisible group" (`proc_macro2::Group { delimiter: None, .. }`). The pattern matcher in `parse_pyo3_attr` / `parse_gen_stub_module_attr` only had `[Ident, Punct, Literal]` arms for `name`, `module`, `rename_all`, and `gen_stub(module = "...")`, so any of them silently disappeared when the value came from a macro meta-variable:

```rust
macro_rules! generate {
    ($name:literal, $mod:literal) => {
        #[gen_stub_pyclass]
        #[pyclass(name = $name, module = $mod)]
        struct Example {}
    };
}
generate!("ExampleName", "my.module");
// Before this PR: stub used struct name "Example" with no module set.
```

#465 fixed this for `name` by adding a dedicated `Group` arm. This PR generalises the fix.

## Approach

Flatten `Group { delimiter: None, .. }` tokens once, up front, before the existing pattern matching runs. After flattening, the same `[Ident, Punct, Literal]` arms handle both written-out literals and macro-substituted values. This:

- removes the special-case `Group` arm for `name` introduced in #465 (no longer needed)
- automatically covers `module`, `rename_all`, and the standalone `#[gen_stub(module = ...)]` attribute
- leaves `signature = (...)` and `constructor = (...)` untouched (their groups are parenthesised, not invisible)

## Tests

Added four unit tests in `pyo3-stub-gen-derive/src/gen_stub/attr.rs` that construct attributes with `proc_macro2::Group::new(Delimiter::None, ...)` — `syn::parse_str` over plain source never produces invisible groups, so simulating macro substitution at the token-tree level is the only way to exercise this code path in a unit test.

E2E (examples + maturin) coverage was considered overkill: the bug is purely in token-stream parsing inside the derive crate.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass
- `task stub-gen` produces no diff in examples (refactor is behaviour-preserving for existing inputs)

Closes #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
