### PR TITLE
Constrain PyO3 range for pyo3-stub-gen 0.22.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ itertools = "0.14.0"
 log = "0.4.32"
 maplit = "1.0.2"
 num-complex = "0.4.6"
-numpy = ">= 0.26.0"
+numpy = ">= 0.26.0, < 0.29.0"
 ordered-float = { version = "5.3", default-features = false }
 prettyplease = "0.2.37"
 proc-macro2 = "1.0.106"
-pyo3 = ">= 0.26.0"
+pyo3 = ">= 0.26.0, < 0.29.0"
 quote = "1.0.45"
 rust_decimal = { version = "1.42", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }


### PR DESCRIPTION
## Summary

This narrows the supported PyO3 and numpy dependency ranges for the 0.22.4 line without changing code.

`pyo3-stub-gen` 0.22.x still supports PyO3 0.26, but the published metadata previously allowed newer PyO3 releases that are not source-compatible with this line. This PR keeps the lower bound at `0.26.0` and adds an upper bound below `0.29.0` for both `pyo3` and `numpy`, preventing Cargo from resolving unsupported PyO3 0.29 (as reported in https://github.com/Jij-Inc/pyo3-stub-gen/issues/475) combinations for 0.22.4 users.

## Notes

PyO3 0.29 support is handled separately on the 0.23 development line, where PyO3 0.26 support can be dropped at a minor release boundary.