### PR TITLE
support PyStubType for functions

### DIFF
--- a/pyo3-stub-gen/src/stub_type.rs
+++ b/pyo3-stub-gen/src/stub_type.rs
@@ -1,5 +1,6 @@
 mod builtins;
 mod collections;
+mod functions;
 mod pyo3;
 
 #[cfg(feature = "numpy")]
@@ -17,6 +18,8 @@ use std::{
     collections::{HashMap, HashSet},
     fmt, ops,
 };
+
+use crate::stub_type::collections::build_type_refs_from_inner;
 
 /// Indicates what to import.
 /// Module: The purpose is to import the entire module(eg import builtins).
@@ -298,6 +301,20 @@ impl TypeInfo {
         }
     }
 
+    pub fn callable_anyarg<R: PyStubType>() -> Self {
+        let info_result = R::type_output();
+        let type_refs = build_type_refs_from_inner(&info_result);
+        let mut import = info_result.import;
+        import.insert("typing".into());
+        let name_result = info_result.name;
+        TypeInfo {
+            name: format!("typing.Callable[..., {name_result}]"),
+            source_module: None,
+            import,
+            type_refs,
+        }
+    }
+
     /// A type annotation of a built-in type provided from `builtins` module, such as `int`, `str`, or `float`. Generic builtin types are also possible, such as `dict[str, str]`.
     pub fn builtin(name: &str) -> Self {
         Self {
@@ -561,6 +578,18 @@ impl ops::BitOr for TypeInfo {
 /// ```
 #[macro_export]
 macro_rules! impl_stub_type {
+    ($ty:ty = fn(...) -> $ret:ty) => {
+        impl ::pyo3_stub_gen::PyStubType for $ty {
+            fn type_output() -> ::pyo3_stub_gen::TypeInfo {
+                ::pyo3_stub_gen::TypeInfo::callable_anyarg::<$ret>()
+            }
+        }
+        impl ::pyo3_stub_gen::runtime::PyRuntimeType for $ty {
+            fn runtime_type_object(py: ::pyo3::Python<'_>) -> ::pyo3::PyResult<::pyo3::Bound<'_, ::pyo3::PyAny>> {
+                Ok(py.get_type::<::pyo3::types::PyAny>().into_any())
+            }
+        }
+    };
     ($ty: ty = $($base:ty)|+) => {
         impl ::pyo3_stub_gen::PyStubType for $ty {
             fn type_output() -> ::pyo3_stub_gen::TypeInfo {

--- a/pyo3-stub-gen/src/stub_type/collections.rs
+++ b/pyo3-stub-gen/src/stub_type/collections.rs
@@ -25,7 +25,7 @@ fn extract_type_identifier(type_name: &str) -> Option<&str> {
 /// Build type_refs HashMap from inner TypeInfo for compound types
 ///
 /// If the inner type is locally-defined and qualified, track it for context-aware rendering.
-fn build_type_refs_from_inner(inner: &TypeInfo) -> HashMap<String, TypeIdentifierRef> {
+pub(crate) fn build_type_refs_from_inner(inner: &TypeInfo) -> HashMap<String, TypeIdentifierRef> {
     let mut type_refs = HashMap::new();
 
     // If inner type is locally defined with a module, track it

--- a/pyo3-stub-gen/src/stub_type/functions.rs
+++ b/pyo3-stub-gen/src/stub_type/functions.rs
@@ -1,0 +1,45 @@
+use super::collections::build_type_refs_from_inner;
+use super::{PyStubType, TypeInfo};
+use crate::runtime::PyRuntimeType;
+use ::pyo3::{Bound, PyAny, PyResult, Python};
+
+macro_rules! impl_tuple {
+    ($($T:ident),*) => {
+        impl<R: PyStubType, $($T: PyStubType),*> PyStubType for fn ($($T),*) -> R {
+            fn type_output() -> TypeInfo {
+                let info_result = R::type_output();
+                let mut type_refs = build_type_refs_from_inner(&info_result);
+                let mut merged = info_result.import;
+                let mut names = Vec::new();
+                $(
+                    let info = $T::type_input();
+                    type_refs.extend(build_type_refs_from_inner(&info));
+                    names.push(info.name);
+                    merged.extend(info.import);
+                )*
+                TypeInfo {
+                    name: format!("typing.Callable[[{}], {}]", names.join(", "), info_result.name),
+                    source_module: None,
+                    import: merged,
+                    type_refs,
+                }
+            }
+        }
+
+        impl<R, $($T),*> PyRuntimeType for fn ($($T),*) -> R {
+            fn runtime_type_object(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+                Ok(py.get_type::<::pyo3::types::PyAny>().into_any())
+            }
+        }
+    }
+}
+
+impl_tuple!(T1);
+impl_tuple!(T1, T2);
+impl_tuple!(T1, T2, T3);
+impl_tuple!(T1, T2, T3, T4);
+impl_tuple!(T1, T2, T3, T4, T5);
+impl_tuple!(T1, T2, T3, T4, T5, T6);
+impl_tuple!(T1, T2, T3, T4, T5, T6, T7);
+impl_tuple!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9);


### PR DESCRIPTION
with this change it is easier to define callable types via
```rust
impl_stub_type!(CustomType1 = fn(...) -> f64);
impl_stub_type!(CustomType2 = fn(String, f64) -> f64);
```

which is generated as:
```python
typing.Callable[..., float]
typing.Callable[[str, float], float]
```

there are already different solutions to this problem, but this variant is more easy to use